### PR TITLE
修复SQLException被吃掉的问题

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/Invocation.java
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/Invocation.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.tracer.plugins.datasource;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
@@ -49,9 +50,11 @@ public class Invocation {
         return args;
     }
 
-    public Object invoke() {
+    public Object invoke() throws Throwable{
         try {
             return method.invoke(target, args);
+        } catch (InvocationTargetException ite) {
+            throw ite.getTargetException();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
类com.alipay.sofa.tracer.plugins.datasource.Invocation的invoke方法未正确处理InvocationTargetException导致SQLException被吃掉。
加上该处理
