### PR TITLE
enhance rest template

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/src/main/java/com/sofa/alipay/tracer/plugins/rest/SofaTracerRestTemplateBuilder.java
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/src/main/java/com/sofa/alipay/tracer/plugins/rest/SofaTracerRestTemplateBuilder.java
@@ -46,6 +46,7 @@ public class SofaTracerRestTemplateBuilder {
         return restTemplate;
     }
 
+    @Deprecated
     public static AsyncRestTemplate buildAsyncRestTemplate() {
         AsyncRestTemplate asyncRestTemplate = new AsyncRestTemplate();
         List<AsyncClientHttpRequestInterceptor> interceptors = new ArrayList<AsyncClientHttpRequestInterceptor>();

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/resttemplate/SofaTracerRestTemplateConfiguration.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/resttemplate/SofaTracerRestTemplateConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.boot.resttemplate;
+
+import com.alipay.sofa.tracer.boot.resttemplate.processor.SofaTracerRestTemplateBeanPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/11 9:43 PM
+ * @since:
+ **/
+@Configuration
+@ConditionalOnWebApplication
+@ConditionalOnProperty(prefix = "com.alipay.sofa.tracer.resttemplate", value = "enable", matchIfMissing = true)
+public class SofaTracerRestTemplateConfiguration {
+
+    @Bean
+    public SofaTracerRestTemplateBeanPostProcessor sofaTracerRestTemplateBeanPostProcessor() {
+        return new SofaTracerRestTemplateBeanPostProcessor(sofaTracerRestTemplateEnhance());
+    }
+
+    @Bean
+    public SofaTracerRestTemplateEnhance sofaTracerRestTemplateEnhance() {
+        return new SofaTracerRestTemplateEnhance();
+    }
+}

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/resttemplate/SofaTracerRestTemplateEnhance.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/resttemplate/SofaTracerRestTemplateEnhance.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.boot.resttemplate;
+
+import com.alipay.common.tracer.core.tracer.AbstractTracer;
+import com.sofa.alipay.tracer.plugins.rest.SofaTracerRestTemplateBuilder;
+import com.sofa.alipay.tracer.plugins.rest.interceptor.RestTemplateInterceptor;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/12 12:02 AM
+ * @since:
+ **/
+public class SofaTracerRestTemplateEnhance {
+
+    private final RestTemplateInterceptor restTemplateInterceptor;
+
+    public SofaTracerRestTemplateEnhance() {
+        AbstractTracer restTemplateTracer = SofaTracerRestTemplateBuilder.getRestTemplateTracer();
+        this.restTemplateInterceptor = new RestTemplateInterceptor(restTemplateTracer);
+    }
+
+    public void enhanceRestTemplateWithSofaTracer(RestTemplate restTemplate) {
+        // check interceptor
+        if (checkRestTemplateInterceptor(restTemplate)) {
+            return;
+        }
+        List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>(
+            restTemplate.getInterceptors());
+        interceptors.add(0, this.restTemplateInterceptor);
+        restTemplate.setInterceptors(interceptors);
+    }
+
+    private boolean checkRestTemplateInterceptor(RestTemplate restTemplate) {
+        for (ClientHttpRequestInterceptor interceptor : restTemplate.getInterceptors()) {
+            if (interceptor instanceof RestTemplateInterceptor) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/resttemplate/processor/SofaTracerRestTemplateBeanPostProcessor.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/resttemplate/processor/SofaTracerRestTemplateBeanPostProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.boot.resttemplate.processor;
+
+import com.alipay.sofa.tracer.boot.resttemplate.SofaTracerRestTemplateEnhance;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/11 11:59 PM
+ * @since:
+ **/
+public class SofaTracerRestTemplateBeanPostProcessor implements BeanPostProcessor {
+
+    private final SofaTracerRestTemplateEnhance sofaTracerRestTemplateEnhance;
+
+    public SofaTracerRestTemplateBeanPostProcessor(SofaTracerRestTemplateEnhance sofaTracerRestTemplateEnhance) {
+        this.sofaTracerRestTemplateEnhance = sofaTracerRestTemplateEnhance;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName)
+                                                                               throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName)
+                                                                              throws BeansException {
+        if (bean instanceof RestTemplate) {
+            RestTemplate restTemplate = (RestTemplate) bean;
+            sofaTracerRestTemplateEnhance.enhanceRestTemplateWithSofaTracer(restTemplate);
+        }
+
+        return bean;
+    }
+}

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/springmvc/configuration/OpenTracingSpringMvcAutoConfiguration.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/springmvc/configuration/OpenTracingSpringMvcAutoConfiguration.java
@@ -21,11 +21,8 @@ import com.alipay.sofa.tracer.boot.properties.SofaTracerProperties;
 import com.alipay.sofa.tracer.boot.springmvc.properties.OpenTracingSpringMvcProperties;
 import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcSofaTracerFilter;
 import com.alipay.sofa.tracer.plugins.webflux.WebfluxSofaTracerFilter;
-import com.sofa.alipay.tracer.plugins.rest.SofaTracerRestTemplateBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -34,8 +31,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.web.client.AsyncRestTemplate;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.WebFilter;
 
 import java.util.List;
@@ -74,20 +69,6 @@ public class OpenTracingSpringMvcAutoConfiguration {
             filterRegistrationBean.setAsyncSupported(true);
             filterRegistrationBean.setOrder(openTracingSpringProperties.getFilterOrder());
             return filterRegistrationBean;
-        }
-
-        @Bean
-        @ConditionalOnClass(RestTemplate.class)
-        @ConditionalOnMissingBean
-        public RestTemplate restTemplate() {
-            return SofaTracerRestTemplateBuilder.buildRestTemplate();
-        }
-
-        @Bean
-        @ConditionalOnClass(AsyncRestTemplate.class)
-        @ConditionalOnMissingBean
-        public AsyncRestTemplate asyncRestTemplate() {
-            return SofaTracerRestTemplateBuilder.buildAsyncRestTemplate();
         }
     }
 

--- a/tracer-sofa-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/tracer-sofa-boot-starter/src/main/resources/META-INF/spring.factories
@@ -4,5 +4,6 @@ com.alipay.sofa.tracer.boot.springmvc.configuration.OpenTracingSpringMvcAutoConf
 com.alipay.sofa.tracer.boot.zipkin.configuration.ZipkinSofaTracerAutoConfiguration,\
 com.alipay.sofa.tracer.boot.datasource.configuration.SofaTracerDataSourceAutoConfiguration,\
 com.alipay.sofa.tracer.boot.springcloud.configuration.SofaTracerFeignClientAutoConfiguration,\
-com.alipay.sofa.tracer.boot.flexible.configuration.TracerAnnotationConfiguration
+com.alipay.sofa.tracer.boot.flexible.configuration.TracerAnnotationConfiguration,\
+com.alipay.sofa.tracer.boot.resttemplate.SofaTracerRestTemplateConfiguration
 org.springframework.context.ApplicationListener=com.alipay.sofa.tracer.boot.listener.SofaTracerConfigurationListener

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/SpringBootWebApplication.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/SpringBootWebApplication.java
@@ -17,7 +17,10 @@
 package com.alipay.sofa.tracer.boot.base;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * SpringBootWebApplication
@@ -32,5 +35,11 @@ public class SpringBootWebApplication {
     public static void main(String[] args) throws Exception {
         SpringApplication springApplication = new SpringApplication(SpringBootWebApplication.class);
         springApplication.run(args);
+    }
+
+    @Bean
+    @LoadBalanced
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/resttemplate/TestRestTemplateRibbon.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/resttemplate/TestRestTemplateRibbon.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.boot.resttemplate;
+
+import com.alipay.sofa.tracer.boot.base.AbstractTestCloudBase;
+import com.sofa.alipay.tracer.plugins.rest.RestTemplateLogEnum;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/12 12:52 AM
+ * @since:
+ **/
+@ActiveProfiles("ribbon")
+@Import({ FeignAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class })
+@EnableFeignClients
+public class TestRestTemplateRibbon extends AbstractTestCloudBase {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Test
+    public void testRestTemplate() throws IOException, InterruptedException {
+        Assert.assertTrue(restTemplate.getInterceptors().size() >= 1);
+        // test for connect error
+        try {
+            restTemplate.getForObject("http://localhost:1234", String.class);
+        } catch (Throwable t) {
+            Assert.assertTrue(t != null);
+        } finally {
+            Thread.sleep(500);
+            //wait for async output
+            List<String> contents = FileUtils.readLines(new File(
+                logDirectoryPath + File.separator
+                        + RestTemplateLogEnum.REST_TEMPLATE_DIGEST.getDefaultLogName()));
+            Assert.assertTrue(contents.size() == 1);
+            Assert.assertTrue(contents.get(0).contains("Connection refused"));
+        }
+
+        String re = restTemplate.getForObject("http://localhost:8890/feign", String.class);
+        Assert.assertTrue(re.equalsIgnoreCase("feign"));
+
+        Thread.sleep(500);
+        //wait for async output
+        List<String> contents = FileUtils.readLines(new File(
+            logDirectoryPath + File.separator
+                    + RestTemplateLogEnum.REST_TEMPLATE_DIGEST.getDefaultLogName()));
+        Assert.assertTrue(contents.size() == 2);
+    }
+}

--- a/tracer-sofa-boot-starter/src/test/resources/application-ribbon.properties
+++ b/tracer-sofa-boot-starter/src/test/resources/application-ribbon.properties
@@ -1,0 +1,2 @@
+spring.application.name=ribbon-client
+server.port=8890


### PR DESCRIPTION
when you use SOFATracer to trace RestTemplate, you can use SofaTracerRestTemplateBuilder to build RestTemplate ,and then send request you want. But sometimes ,  we cannot forcing a user to choose this way. 

Now , we provide a SofaTracerRestTemplateBeanPostProcessor to decorate your RestTemplate bean instance, if you want trace your RestTemplate's request, just stating your RestTemplate bean.
