### PR TITLE
fix web client stat success mark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,10 @@
                 </plugins>
             </build>
             <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
                 <repository>
                     <id>ossrh</id>
                     <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
@@ -456,6 +460,10 @@
                     <id>ossrh</id>
                     <url>https://oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
+                <repository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
             </distributionManagement>
         </profile>
     </profiles>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/src/main/java/com/alipay/sofa/tracer/plugins/httpclient/HttpClientStatJsonReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/src/main/java/com/alipay/sofa/tracer/plugins/httpclient/HttpClientStatJsonReporter.java
@@ -49,8 +49,7 @@ public class HttpClientStatJsonReporter extends AbstractSofaTracerStatisticRepor
         statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));
         //success
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        boolean success = (resultCode != null && resultCode.length() > 0 && this
-            .isHttpOrMvcSuccess(resultCode));
+        boolean success = isWebHttpClientSuccess(resultCode);
         statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
             : SofaTracerConstant.STAT_FLAG_FAILS);
         //end

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/src/main/java/com/alipay/sofa/tracer/plugins/httpclient/HttpClientStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/src/main/java/com/alipay/sofa/tracer/plugins/httpclient/HttpClientStatReporter.java
@@ -46,10 +46,11 @@ public class HttpClientStatReporter extends AbstractSofaTracerStatisticReporter 
         String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
         statKey.setKey(buildString(new String[] { localApp, requestUrl, methodName }));
 
+        //success
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        statKey
-            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
-                : SofaTracerConstant.STAT_FLAG_FAILS);
+        boolean success = isWebHttpClientSuccess(resultCode);
+        statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
+            : SofaTracerConstant.STAT_FLAG_FAILS);
 
         statKey.setEnd(buildString(new String[] { TracerUtils.getLoadTestMark(sofaTracerSpan) }));
         //pressure mark

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/src/main/java/com/alipay/sofa/tracer/plugins/okhttp/OkHttpStatJsonReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/src/main/java/com/alipay/sofa/tracer/plugins/okhttp/OkHttpStatJsonReporter.java
@@ -47,8 +47,7 @@ public class OkHttpStatJsonReporter extends AbstractSofaTracerStatisticReporter 
         statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));
         //success
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        boolean success = (resultCode != null && resultCode.length() > 0 && this
-            .isHttpOrMvcSuccess(resultCode));
+        boolean success = isWebHttpClientSuccess(resultCode);
         statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
             : SofaTracerConstant.STAT_FLAG_FAILS);
         //end

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/src/main/java/com/alipay/sofa/tracer/plugins/okhttp/OkHttpStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/src/main/java/com/alipay/sofa/tracer/plugins/okhttp/OkHttpStatReporter.java
@@ -45,10 +45,11 @@ public class OkHttpStatReporter extends AbstractSofaTracerStatisticReporter {
         String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
         statKey.setKey(buildString(new String[] { localApp, requestUrl, methodName }));
 
+        //success
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        statKey
-            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
-                : SofaTracerConstant.STAT_FLAG_FAILS);
+        boolean success = isWebHttpClientSuccess(resultCode);
+        statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
+            : SofaTracerConstant.STAT_FLAG_FAILS);
 
         statKey.setEnd(buildString(new String[] { TracerUtils.getLoadTestMark(sofaTracerSpan) }));
         //pressure mark

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/src/main/java/com/sofa/alipay/tracer/plugins/rest/RestTemplateStatJsonReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/src/main/java/com/sofa/alipay/tracer/plugins/rest/RestTemplateStatJsonReporter.java
@@ -46,8 +46,7 @@ public class RestTemplateStatJsonReporter extends AbstractSofaTracerStatisticRep
         statKey.addKey(CommonSpanTags.METHOD, tagsWithStr.get(CommonSpanTags.METHOD));
         //success
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        boolean success = (resultCode != null && resultCode.length() > 0 && this
-            .isHttpOrMvcSuccess(resultCode));
+        boolean success = isWebHttpClientSuccess(resultCode);
         statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
             : SofaTracerConstant.STAT_FLAG_FAILS);
         //pressure mark

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/src/main/java/com/sofa/alipay/tracer/plugins/rest/RestTemplateStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/src/main/java/com/sofa/alipay/tracer/plugins/rest/RestTemplateStatReporter.java
@@ -45,12 +45,11 @@ public class RestTemplateStatReporter extends AbstractSofaTracerStatisticReporte
         //method name
         String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
         statKey.setKey(buildString(new String[] { localApp, requestUrl, methodName }));
-
+        //success
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        statKey
-            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
-                : SofaTracerConstant.STAT_FLAG_FAILS);
-
+        boolean success = isWebHttpClientSuccess(resultCode);
+        statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
+            : SofaTracerConstant.STAT_FLAG_FAILS);
         statKey.setEnd(buildString(new String[] { TracerUtils.getLoadTestMark(sofaTracerSpan) }));
         //pressure mark
         statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/repoters/OpenFeignStatJsonReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/repoters/OpenFeignStatJsonReporter.java
@@ -44,8 +44,7 @@ public class OpenFeignStatJsonReporter extends AbstractSofaTracerStatisticReport
         statKey.addKey(CommonSpanTags.REQUEST_URL, tagsWithStr.get(CommonSpanTags.REQUEST_URL));
         statKey.addKey(CommonSpanTags.METHOD, tagsWithStr.get(CommonSpanTags.METHOD));
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        boolean success = (resultCode != null && resultCode.length() > 0 && this
-            .isHttpOrMvcSuccess(resultCode));
+        boolean success = isWebHttpClientSuccess(resultCode);
         statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
             : SofaTracerConstant.STAT_FLAG_FAILS);
         //pressure mark

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/repoters/OpenFeignStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/repoters/OpenFeignStatReporter.java
@@ -46,10 +46,11 @@ public class OpenFeignStatReporter extends AbstractSofaTracerStatisticReporter {
         String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
         statKey.setKey(buildString(new String[] { localApp, requestUrl, methodName }));
 
+        //success
         String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
-        statKey
-            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
-                : SofaTracerConstant.STAT_FLAG_FAILS);
+        boolean success = isWebHttpClientSuccess(resultCode);
+        statKey.setResult(success ? SofaTracerConstant.STAT_FLAG_SUCCESS
+            : SofaTracerConstant.STAT_FLAG_FAILS);
 
         statKey.setEnd(buildString(new String[] { TracerUtils.getLoadTestMark(sofaTracerSpan) }));
         //pressure mark

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/reporter/stat/AbstractSofaTracerStatisticReporter.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/reporter/stat/AbstractSofaTracerStatisticReporter.java
@@ -23,6 +23,7 @@ import com.alipay.common.tracer.core.appender.file.LoadTestAwareAppender;
 import com.alipay.common.tracer.core.appender.self.SelfLog;
 import com.alipay.common.tracer.core.appender.self.Timestamp;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterCycleTimesManager;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterManager;
 import com.alipay.common.tracer.core.reporter.stat.model.StatKey;
@@ -359,5 +360,11 @@ public abstract class AbstractSofaTracerStatisticReporter implements SofaTracerS
     protected boolean isHttpOrMvcSuccess(String resultCode) {
         return resultCode.charAt(0) == '1' || resultCode.charAt(0) == '2'
                || "302".equals(resultCode.trim()) || ("301".equals(resultCode.trim()));
+    }
+
+    protected boolean isWebHttpClientSuccess(String resultCode) {
+        return StringUtils.isNotBlank(resultCode)
+               && (isHttpOrMvcSuccess(resultCode) || SofaTracerConstant.RESULT_CODE_SUCCESS
+                   .equals(resultCode));
     }
 }

--- a/tracer-samples/pom.xml
+++ b/tracer-samples/pom.xml
@@ -39,6 +39,14 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
修复对于 httpclient/resttemplate/feignclient/okhttp 等web 客户端调用组件来说，当前 response 返回 200 时，统计日志中计算 success 出现 false情况