### PR TITLE
disable zipkin reporter by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ nb-configuration.xml
 coverage-report
 logs
 *.log
+pom.xml.versionsBackup

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/configuration/ZipkinSofaTracerAutoConfiguration.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/configuration/ZipkinSofaTracerAutoConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @Configuration
 @EnableConfigurationProperties(ZipkinSofaTracerProperties.class)
-@ConditionalOnProperty(value = "com.alipay.sofa.tracer.zipkin.enabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "com.alipay.sofa.tracer.zipkin.enabled", matchIfMissing = false)
 @ConditionalOnClass({ zipkin2.Span.class, zipkin2.reporter.AsyncReporter.class, RestTemplate.class })
 public class ZipkinSofaTracerAutoConfiguration {
 

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/properties/ZipkinSofaTracerProperties.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/zipkin/properties/ZipkinSofaTracerProperties.java
@@ -31,7 +31,10 @@ public class ZipkinSofaTracerProperties {
      * URL of the zipkin query server instance.
      */
     private String  baseUrl = "http://localhost:9411/";
-    private boolean enabled = true;
+    /**
+     * zipkin reporter is disabled by default
+     */
+    private boolean enabled = false;
     /**
      * When enabled, spans are gzipped before sent to the zipkin server
      */


### PR DESCRIPTION
### Motivation:

Disable zipkin reporter by default.

### Modification:

Modify ZipkinSofaTracerAutoConfiguration.

### Result:
Zipkin reporter is now disabled by default.

#339 