### PR TITLE
Bugfix/dubbo attachment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>tracer-test/logback-test</module>
         <module>tracer-test/log4j2-test</module>
         <module>tracer-test/log4j-test</module>
+        <module>sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>3.0.12.JST</version>
+    <version>3.0.12.JST.1</version>
     <packaging>pom</packaging>
     <name>tracer-all-parent</name>
     <description>Alipay SOFATracer Log Implemented by OpenTracing</description>
@@ -38,7 +38,7 @@
 
     <properties>
         <opentracing.version>0.22.0</opentracing.version>
-        <sofa.tracer.version>3.0.12.JST</sofa.tracer.version>
+        <sofa.tracer.version>3.0.12.JST.1</sofa.tracer.version>
         <java.compiler.source.version>1.8</java.compiler.source.version>
         <java.compiler.target.version>1.8</java.compiler.target.version>
         <jmh.version>1.9.3</jmh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
-                <artifactId>sofa-tracer-dubbo-plugin</artifactId>
+                <artifactId>sofa-tracer-dubbo-common-plugin</artifactId>
                 <version>${sofa.tracer.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>3.0.12.JST.1</version>
+    <version>3.0.12</version>
     <packaging>pom</packaging>
     <name>tracer-all-parent</name>
     <description>Alipay SOFATracer Log Implemented by OpenTracing</description>
@@ -38,7 +38,6 @@
 
     <properties>
         <opentracing.version>0.22.0</opentracing.version>
-        <sofa.tracer.version>3.0.12.JST.1</sofa.tracer.version>
         <java.compiler.source.version>1.8</java.compiler.source.version>
         <java.compiler.target.version>1.8</java.compiler.target.version>
         <jmh.version>1.9.3</jmh.version>
@@ -90,67 +89,67 @@
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>tracer-core</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>tracer-extensions</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-springmvc-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-httpclient-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-okhttp-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-resttmplate-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-datasource-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-zipkin-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-spring-cloud-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-dubbo-common-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-flexible-plugin</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>tracer-all</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>tracer-sofa-boot-starter</artifactId>
-                <version>${sofa.tracer.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <!-- opentracing dependency -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>3.0.11</version>
+    <version>3.0.12.JST</version>
     <packaging>pom</packaging>
     <name>tracer-all-parent</name>
     <description>Alipay SOFATracer Log Implemented by OpenTracing</description>
@@ -37,7 +37,7 @@
 
     <properties>
         <opentracing.version>0.22.0</opentracing.version>
-        <sofa.tracer.version>3.0.11</sofa.tracer.version>
+        <sofa.tracer.version>3.0.12.JST</sofa.tracer.version>
         <java.compiler.source.version>1.8</java.compiler.source.version>
         <java.compiler.target.version>1.8</java.compiler.target.version>
         <jmh.version>1.9.3</jmh.version>
@@ -104,6 +104,11 @@
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>sofa-tracer-httpclient-plugin</artifactId>
+                <version>${sofa.tracer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alipay.sofa</groupId>
+                <artifactId>sofa-tracer-okhttp-plugin</artifactId>
                 <version>${sofa.tracer.version}</version>
             </dependency>
             <dependency>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tracer-all-parent</artifactId>
+        <groupId>com.alipay.sofa</groupId>
+        <version>3.0.8-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sofa-tracer-dubbo-common-plugin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>2.6.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>2.7.3</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>tracer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.8-SNAPSHOT</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/constants/AttachmentKeyConstants.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/constants/AttachmentKeyConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.constants;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/7/26 5:25 PM
+ * @since:
+ **/
+public class AttachmentKeyConstants {
+
+    public static final String SERVER_DESERIALIZE_SIZE = "server.deserialize.size";
+    public static final String SERVER_SERIALIZE_SIZE   = "server.serialize.size";
+    public static final String CLIENT_DESERIALIZE_SIZE = "client.deserialize.size";
+    public static final String CLIENT_SERIALIZE_SIZE   = "client.serialize.size";
+
+    public static final String SERVER_DESERIALIZE_TIME = "server.deserialize.time";
+    public static final String SERVER_SERIALIZE_TIME   = "server.serialize.time";
+    public static final String CLIENT_DESERIALIZE_TIME = "client.deserialize.time";
+    public static final String CLIENT_SERIALIZE_TIME   = "client.serialize.time";
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboClientDigestEncoder.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboClientDigestEncoder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.encoder;
+
+import com.alipay.common.tracer.core.appender.builder.JsonStringBuilder;
+import com.alipay.common.tracer.core.appender.builder.XStringBuilder;
+import com.alipay.common.tracer.core.middleware.parent.AbstractDigestSpanEncoder;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.StringUtils;
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+import io.opentracing.tag.Tags;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/1 2:46 PM
+ * @since:
+ **/
+public class DubboClientDigestEncoder extends AbstractDigestSpanEncoder {
+
+    @Override
+    protected void appendComponentSlot(XStringBuilder xsb, JsonStringBuilder jsb,
+                                       SofaTracerSpan span) {
+        Map<String, String> tagWithStr = span.getTagsWithStr();
+        Map<String, Number> tagWithNum = span.getTagsWithNumber();
+        //protocol
+        xsb.append(tagWithStr.get(CommonSpanTags.PROTOCOL));
+        // service
+        xsb.append(tagWithStr.get(CommonSpanTags.SERVICE));
+        // method
+        xsb.append(tagWithStr.get(CommonSpanTags.METHOD));
+        // invoke type
+        xsb.append(tagWithStr.get(CommonSpanTags.INVOKE_TYPE));
+        // remote host
+        xsb.append(tagWithStr.get(CommonSpanTags.REMOTE_HOST));
+        // remote port
+        xsb.append(tagWithStr.get(CommonSpanTags.REMOTE_PORT));
+        // local port
+        xsb.append(tagWithStr.get(CommonSpanTags.LOCAL_HOST));
+        // client.serialize.time
+        xsb.append(tagWithNum.get(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME) + "");
+        // client.deserialize.time
+        xsb.append(tagWithNum.get(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME) + "");
+        // client.serialize.size
+        Number reqSizeNum = tagWithNum.get(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE);
+        xsb.append(reqSizeNum == null ? 0 : reqSizeNum.longValue());
+        // client.deserialize.size
+        Number respSizeNum = tagWithNum.get(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE);
+        xsb.append(respSizeNum == null ? 0 : respSizeNum.longValue());
+        // error message
+        xsb.append(StringUtils.isBlank(tagWithStr.get(Tags.ERROR.getKey())) ? "" : tagWithStr
+            .get(Tags.ERROR.getKey()));
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboClientDigestJsonEncoder.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboClientDigestJsonEncoder.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.encoder;
+
+import com.alipay.common.tracer.core.appender.builder.JsonStringBuilder;
+import com.alipay.common.tracer.core.appender.builder.XStringBuilder;
+import com.alipay.common.tracer.core.middleware.parent.AbstractDigestSpanEncoder;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.StringUtils;
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+import io.opentracing.tag.Tags;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 3:56 PM
+ * @since:
+ **/
+public class DubboClientDigestJsonEncoder extends AbstractDigestSpanEncoder {
+
+    @Override
+    protected void appendComponentSlot(XStringBuilder xsb, JsonStringBuilder jsb,
+                                       SofaTracerSpan span) {
+        Map<String, String> tagStr = span.getTagsWithStr();
+        Map<String, Number> tagNum = span.getTagsWithNumber();
+
+        // protocol
+        jsb.append(CommonSpanTags.PROTOCOL, tagStr.get(CommonSpanTags.PROTOCOL));
+        // serviceName
+        jsb.append(CommonSpanTags.SERVICE, tagStr.get(CommonSpanTags.SERVICE));
+        // method
+        jsb.append(CommonSpanTags.METHOD, tagStr.get(CommonSpanTags.METHOD));
+        //invoke type
+        jsb.append(CommonSpanTags.INVOKE_TYPE, tagStr.get(CommonSpanTags.INVOKE_TYPE));
+        //target ip
+        jsb.append(CommonSpanTags.REMOTE_HOST, tagStr.get(CommonSpanTags.REMOTE_HOST));
+        //target port
+        jsb.append(CommonSpanTags.REMOTE_PORT, tagStr.get(CommonSpanTags.REMOTE_PORT));
+        //local ip
+        jsb.append(CommonSpanTags.LOCAL_HOST, tagStr.get(CommonSpanTags.LOCAL_HOST));
+        //request serialize time
+        jsb.append(CommonSpanTags.CLIENT_SERIALIZE_TIME,
+            tagNum.get(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME));
+        //response deserialize time
+        jsb.append(CommonSpanTags.CLIENT_DESERIALIZE_TIME,
+            tagNum.get(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME));
+        //Request Body bytes length
+        Number reqSizeNum = tagNum.get(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE);
+        jsb.append(CommonSpanTags.REQ_SIZE, reqSizeNum == null ? 0 : reqSizeNum.longValue());
+        //Response Body bytes length
+        Number respSizeNum = tagNum.get(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE);
+        jsb.append(CommonSpanTags.RESP_SIZE, respSizeNum == null ? 0 : respSizeNum.longValue());
+
+        //error message
+        if (StringUtils.isNotBlank(tagStr.get(Tags.ERROR.getKey()))) {
+            jsb.append(Tags.ERROR.getKey(), tagStr.get(Tags.ERROR.getKey()));
+        } else {
+            jsb.append(Tags.ERROR.getKey(), StringUtils.EMPTY_STRING);
+        }
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboServerDigestEncoder.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboServerDigestEncoder.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.encoder;
+
+import com.alipay.common.tracer.core.appender.builder.JsonStringBuilder;
+import com.alipay.common.tracer.core.appender.builder.XStringBuilder;
+import com.alipay.common.tracer.core.middleware.parent.AbstractDigestSpanEncoder;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.StringUtils;
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+import io.opentracing.tag.Tags;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/1 2:46 PM
+ * @since:
+ **/
+public class DubboServerDigestEncoder extends AbstractDigestSpanEncoder {
+
+    @Override
+    protected void appendComponentSlot(XStringBuilder xsb, JsonStringBuilder jsb,
+                                       SofaTracerSpan span) {
+        Map<String, String> tagWithStr = span.getTagsWithStr();
+        Map<String, Number> tagWithNum = span.getTagsWithNumber();
+
+        //protocol
+        xsb.append(tagWithStr.get(CommonSpanTags.PROTOCOL));
+        // service
+        xsb.append(tagWithStr.get(CommonSpanTags.SERVICE));
+        // method
+        xsb.append(tagWithStr.get(CommonSpanTags.METHOD));
+        // invoke type
+        xsb.append(tagWithStr.get(CommonSpanTags.INVOKE_TYPE));
+        xsb.append(tagWithStr.get(CommonSpanTags.REMOTE_HOST));
+        xsb.append(tagWithStr.get(CommonSpanTags.REMOTE_PORT));
+        xsb.append(tagWithStr.get(CommonSpanTags.LOCAL_HOST));
+        xsb.append(tagWithNum.get(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME) + "");
+        xsb.append(tagWithNum.get(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME) + "");
+        //Request Body bytes length
+        long serializeTime = getTime(tagWithNum.get(AttachmentKeyConstants.SERVER_SERIALIZE_TIME));
+        long deserializeTime = getTime(tagWithNum
+            .get(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME));
+        xsb.append(String.valueOf(serializeTime));
+        xsb.append(String.valueOf(deserializeTime));
+        Number reqSizeNum = tagWithNum.get(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE);
+        xsb.append(reqSizeNum == null ? 0 : reqSizeNum.longValue());
+        Number respSizeNum = tagWithNum.get(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE);
+        xsb.append(respSizeNum == null ? 0 : respSizeNum.longValue());
+
+        xsb.append(StringUtils.isBlank(tagWithStr.get(Tags.ERROR.getKey())) ? "" : tagWithStr
+            .get(Tags.ERROR.getKey()));
+    }
+
+    private long getTime(Number number) {
+        if (number != null) {
+            return number.longValue();
+        }
+        return 0;
+    }
+
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboServerDigestJsonEncoder.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/encoder/DubboServerDigestJsonEncoder.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.encoder;
+
+import com.alipay.common.tracer.core.appender.builder.JsonStringBuilder;
+import com.alipay.common.tracer.core.appender.builder.XStringBuilder;
+import com.alipay.common.tracer.core.middleware.parent.AbstractDigestSpanEncoder;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.StringUtils;
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+import io.opentracing.tag.Tags;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 4:19 PM
+ * @since:
+ **/
+public class DubboServerDigestJsonEncoder extends AbstractDigestSpanEncoder {
+
+    @Override
+    protected void appendComponentSlot(XStringBuilder xsb, JsonStringBuilder jsb,
+                                       SofaTracerSpan span) {
+        Map<String, String> tagStr = span.getTagsWithStr();
+        Map<String, Number> tagNum = span.getTagsWithNumber();
+
+        //protocol
+        jsb.append(CommonSpanTags.PROTOCOL, tagStr.get(CommonSpanTags.PROTOCOL));
+        //serviceName
+        jsb.append(CommonSpanTags.SERVICE, tagStr.get(CommonSpanTags.SERVICE));
+        //method
+        jsb.append(CommonSpanTags.METHOD, tagStr.get(CommonSpanTags.METHOD));
+        //local ip
+        jsb.append(CommonSpanTags.LOCAL_HOST, tagStr.get(CommonSpanTags.LOCAL_HOST));
+        //local port
+        jsb.append(CommonSpanTags.LOCAL_PORT, tagStr.get(CommonSpanTags.LOCAL_PORT));
+
+        long serializeTime = getTime(tagNum.get(AttachmentKeyConstants.SERVER_SERIALIZE_TIME));
+        jsb.append(CommonSpanTags.SERVER_SERIALIZE_TIME, serializeTime);
+        long deserializeTime = getTime(tagNum.get(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME));
+        jsb.append(CommonSpanTags.SERVER_DESERIALIZE_TIME, deserializeTime);
+
+        Number reqSizeNum = tagNum.get(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE);
+        jsb.append(CommonSpanTags.REQ_SIZE, reqSizeNum == null ? 0 : reqSizeNum.longValue());
+        Number respSizeNum = tagNum.get(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE);
+        jsb.append(CommonSpanTags.RESP_SIZE, respSizeNum == null ? 0 : respSizeNum.longValue());
+
+        //error message
+        if (StringUtils.isNotBlank(tagStr.get(Tags.ERROR.getKey()))) {
+            jsb.append(Tags.ERROR.getKey(), tagStr.get(Tags.ERROR.getKey()));
+        } else {
+            jsb.append(Tags.ERROR.getKey(), StringUtils.EMPTY_STRING);
+        }
+    }
+
+    private long getTime(Number number) {
+        if (number != null) {
+            return number.longValue();
+        }
+        return 0;
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/enums/DubboLogEnum.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/enums/DubboLogEnum.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.enums;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 3:43 PM
+ * @since:
+ **/
+public enum DubboLogEnum {
+
+    DUBBO_SERVER_DIGEST("dubbo_server_digest_log_name", "dubbo-server-digest.log",
+                        "dubbo_server_digest_rolling"),
+
+    DUBBO_SERVER_STAT("dubbo_server_stat_log_name", "dubbo-server-stat.log",
+                      "dubbo_server_stat_rolling"),
+
+    DUBBO_CLIENT_DIGEST("dubbo_client_digest_log_name", "dubbo-client-digest.log",
+                        "dubbo_client_digest_rolling"),
+
+    DUBBO_CLIENT_STAT("dubbo_client_stat_log_name", "dubbo-client-stat.log",
+                      "dubbot_client_stat_rolling");
+
+    private String logNameKey;
+    private String defaultLogName;
+    private String rollingKey;
+
+    DubboLogEnum(String logNameKey, String defaultLogName, String rollingKey) {
+        this.logNameKey = logNameKey;
+        this.defaultLogName = defaultLogName;
+        this.rollingKey = rollingKey;
+    }
+
+    public String getLogNameKey() {
+        //log reserve config key
+        return logNameKey;
+    }
+
+    public String getDefaultLogName() {
+        return defaultLogName;
+    }
+
+    public String getRollingKey() {
+        return rollingKey;
+    }
+
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboClientStatJsonReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboClientStatJsonReporter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.stat;
+
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
+import com.alipay.common.tracer.core.reporter.stat.AbstractSofaTracerStatisticReporter;
+import com.alipay.common.tracer.core.reporter.stat.model.StatMapKey;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.TracerUtils;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 4:23 PM
+ * @since:
+ **/
+public class DubboClientStatJsonReporter extends AbstractSofaTracerStatisticReporter {
+
+    public DubboClientStatJsonReporter(String statTracerName, String rollingPolicy,
+                                       String logReserveConfig) {
+        super(statTracerName, rollingPolicy, logReserveConfig);
+    }
+
+    @Override
+    public void doReportStat(SofaTracerSpan sofaTracerSpan) {
+        //tags
+        Map<String, String> tagsWithStr = sofaTracerSpan.getTagsWithStr();
+        StatMapKey statKey = new StatMapKey();
+        String appName = tagsWithStr.get(CommonSpanTags.LOCAL_APP);
+        //service name
+        String serviceName = tagsWithStr.get(CommonSpanTags.SERVICE);
+        //method name
+        String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
+        statKey.addKey(CommonSpanTags.LOCAL_APP, appName);
+        statKey.addKey(CommonSpanTags.SERVICE, serviceName);
+        statKey.addKey(CommonSpanTags.METHOD, methodName);
+
+        String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
+        statKey
+            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
+                : SofaTracerConstant.STAT_FLAG_FAILS);
+        statKey.setEnd(buildString(new String[] { getLoadTestMark(sofaTracerSpan) }));
+        statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));
+
+        long duration = sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime();
+        long[] values = new long[] { 1, duration };
+        this.addStat(statKey, values);
+    }
+
+    protected String getLoadTestMark(SofaTracerSpan span) {
+        if (TracerUtils.isLoadTest(span)) {
+            return "T";
+        } else {
+            return "F";
+        }
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboClientStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboClientStatReporter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.stat;
+
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
+import com.alipay.common.tracer.core.reporter.stat.AbstractSofaTracerStatisticReporter;
+import com.alipay.common.tracer.core.reporter.stat.model.StatKey;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.TracerUtils;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/1 5:27 PM
+ * @since:
+ **/
+public class DubboClientStatReporter extends AbstractSofaTracerStatisticReporter {
+
+    public DubboClientStatReporter(String statTracerName, String rollingPolicy,
+                                   String logReserveConfig) {
+        super(statTracerName, rollingPolicy, logReserveConfig);
+    }
+
+    @Override
+    public void doReportStat(SofaTracerSpan sofaTracerSpan) {
+        Map<String, String> tagsWithStr = sofaTracerSpan.getTagsWithStr();
+        StatKey statKey = new StatKey();
+        String appName = tagsWithStr.get(CommonSpanTags.LOCAL_APP);
+        //service name
+        String serviceName = tagsWithStr.get(CommonSpanTags.SERVICE);
+        //method name
+        String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
+        statKey.setKey(buildString(new String[] { appName, serviceName, methodName }));
+        String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
+        statKey
+            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
+                : SofaTracerConstant.STAT_FLAG_FAILS);
+
+        statKey.setEnd(buildString(new String[] { TracerUtils.getLoadTestMark(sofaTracerSpan) }));
+        //pressure mark
+        statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));
+        //value the count and duration
+        long duration = sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime();
+        long[] values = new long[] { 1, duration };
+        //reserve
+        this.addStat(statKey, values);
+    }
+
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboServerStatJsonReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboServerStatJsonReporter.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.stat;
+
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
+import com.alipay.common.tracer.core.reporter.stat.AbstractSofaTracerStatisticReporter;
+import com.alipay.common.tracer.core.reporter.stat.model.StatMapKey;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.TracerUtils;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 4:23 PM
+ * @since:
+ **/
+public class DubboServerStatJsonReporter extends AbstractSofaTracerStatisticReporter {
+
+    public DubboServerStatJsonReporter(String statTracerName, String rollingPolicy,
+                                       String logReserveConfig) {
+        super(statTracerName, rollingPolicy, logReserveConfig);
+    }
+
+    @Override
+    public void doReportStat(SofaTracerSpan sofaTracerSpan) {
+        //tags
+        Map<String, String> tagsWithStr = sofaTracerSpan.getTagsWithStr();
+        StatMapKey statKey = new StatMapKey();
+        String appName = tagsWithStr.get(CommonSpanTags.LOCAL_APP);
+        //service name
+        String serviceName = tagsWithStr.get(CommonSpanTags.SERVICE);
+        //method name
+        String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
+
+        statKey.addKey(CommonSpanTags.LOCAL_APP, appName);
+        statKey.addKey(CommonSpanTags.SERVICE, serviceName);
+        statKey.addKey(CommonSpanTags.METHOD, methodName);
+
+        String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
+        statKey
+            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
+                : SofaTracerConstant.STAT_FLAG_FAILS);
+        statKey.setEnd(buildString(new String[] { getLoadTestMark(sofaTracerSpan) }));
+        statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));
+
+        long duration = sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime();
+        long[] values = new long[] { 1, duration };
+        this.addStat(statKey, values);
+    }
+
+    protected String getLoadTestMark(SofaTracerSpan span) {
+        if (TracerUtils.isLoadTest(span)) {
+            return "T";
+        } else {
+            return "F";
+        }
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboServerStatReporter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/stat/DubboServerStatReporter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.stat;
+
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
+import com.alipay.common.tracer.core.reporter.stat.AbstractSofaTracerStatisticReporter;
+import com.alipay.common.tracer.core.reporter.stat.model.StatKey;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.TracerUtils;
+
+import java.util.Map;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/9/1 5:36 PM
+ * @since:
+ **/
+public class DubboServerStatReporter extends AbstractSofaTracerStatisticReporter {
+
+    public DubboServerStatReporter(String statTracerName, String rollingPolicy,
+                                   String logReserveConfig) {
+        super(statTracerName, rollingPolicy, logReserveConfig);
+    }
+
+    @Override
+    public void doReportStat(SofaTracerSpan sofaTracerSpan) {
+        Map<String, String> tagsWithStr = sofaTracerSpan.getTagsWithStr();
+        StatKey statKey = new StatKey();
+        String appName = tagsWithStr.get(CommonSpanTags.LOCAL_APP);
+        //service name
+        String serviceName = tagsWithStr.get(CommonSpanTags.SERVICE);
+        //method name
+        String methodName = tagsWithStr.get(CommonSpanTags.METHOD);
+        statKey.setKey(buildString(new String[] { appName, serviceName, methodName }));
+        String resultCode = tagsWithStr.get(CommonSpanTags.RESULT_CODE);
+        statKey
+            .setResult(SofaTracerConstant.RESULT_CODE_SUCCESS.equals(resultCode) ? SofaTracerConstant.STAT_FLAG_SUCCESS
+                : SofaTracerConstant.STAT_FLAG_FAILS);
+        statKey.setEnd(buildString(new String[] { TracerUtils.getLoadTestMark(sofaTracerSpan) }));
+        //pressure mark
+        statKey.setLoadTest(TracerUtils.isLoadTest(sofaTracerSpan));
+        //value the count and duration
+        long duration = sofaTracerSpan.getEndTime() - sofaTracerSpan.getStartTime();
+        long[] values = new long[] { 1, duration };
+        //reserve
+        this.addStat(statKey, values);
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/tracer/DubboConsumerSofaTracer.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/tracer/DubboConsumerSofaTracer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.tracer;
+
+import com.alipay.common.tracer.core.appender.encoder.SpanEncoder;
+import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.common.tracer.core.constants.ComponentNameConstants;
+import com.alipay.common.tracer.core.reporter.stat.AbstractSofaTracerStatisticReporter;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.tracer.AbstractClientTracer;
+import com.alipay.sofa.tracer.plugins.dubbo.encoder.DubboClientDigestEncoder;
+import com.alipay.sofa.tracer.plugins.dubbo.encoder.DubboClientDigestJsonEncoder;
+import com.alipay.sofa.tracer.plugins.dubbo.enums.DubboLogEnum;
+import com.alipay.sofa.tracer.plugins.dubbo.stat.DubboClientStatJsonReporter;
+import com.alipay.sofa.tracer.plugins.dubbo.stat.DubboClientStatReporter;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 3:33 PM
+ * @since:
+ **/
+public class DubboConsumerSofaTracer extends AbstractClientTracer {
+
+    private volatile static DubboConsumerSofaTracer dubboConsumerSofaTracer = null;
+
+    public static DubboConsumerSofaTracer getDubboConsumerSofaTracerSingleton() {
+        if (dubboConsumerSofaTracer == null) {
+            synchronized (DubboConsumerSofaTracer.class) {
+                if (dubboConsumerSofaTracer == null) {
+                    dubboConsumerSofaTracer = new DubboConsumerSofaTracer(
+                        ComponentNameConstants.DUBBO_CLIENT);
+                }
+            }
+        }
+        return dubboConsumerSofaTracer;
+    }
+
+    public DubboConsumerSofaTracer(String tracerType) {
+        super(tracerType);
+    }
+
+    @Override
+    protected String getClientDigestReporterLogName() {
+        return DubboLogEnum.DUBBO_CLIENT_DIGEST.getDefaultLogName();
+    }
+
+    @Override
+    protected String getClientDigestReporterRollingKey() {
+        return DubboLogEnum.DUBBO_CLIENT_DIGEST.getRollingKey();
+    }
+
+    @Override
+    protected String getClientDigestReporterLogNameKey() {
+        return DubboLogEnum.DUBBO_CLIENT_DIGEST.getLogNameKey();
+    }
+
+    @Override
+    protected SpanEncoder<SofaTracerSpan> getClientDigestEncoder() {
+        if (SofaTracerConfiguration.isJsonOutput()) {
+            return new DubboClientDigestJsonEncoder();
+        } else {
+            return new DubboClientDigestEncoder();
+        }
+    }
+
+    @Override
+    protected AbstractSofaTracerStatisticReporter generateClientStatReporter() {
+        DubboLogEnum dubboClientStat = DubboLogEnum.DUBBO_CLIENT_STAT;
+        String statLog = dubboClientStat.getDefaultLogName();
+        String statRollingPolicy = SofaTracerConfiguration.getRollingPolicy(dubboClientStat
+            .getRollingKey());
+        String statLogReserveConfig = SofaTracerConfiguration.getLogReserveConfig(dubboClientStat
+            .getLogNameKey());
+        if (SofaTracerConfiguration.isJsonOutput()) {
+            return new DubboClientStatJsonReporter(statLog, statRollingPolicy, statLogReserveConfig);
+        } else {
+            return new DubboClientStatReporter(statLog, statRollingPolicy, statLogReserveConfig);
+        }
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/tracer/DubboProviderSofaTracer.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo/tracer/DubboProviderSofaTracer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo.tracer;
+
+import com.alipay.common.tracer.core.appender.encoder.SpanEncoder;
+import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.common.tracer.core.constants.ComponentNameConstants;
+import com.alipay.common.tracer.core.reporter.stat.AbstractSofaTracerStatisticReporter;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.tracer.AbstractServerTracer;
+import com.alipay.sofa.tracer.plugins.dubbo.encoder.DubboServerDigestEncoder;
+import com.alipay.sofa.tracer.plugins.dubbo.encoder.DubboServerDigestJsonEncoder;
+import com.alipay.sofa.tracer.plugins.dubbo.enums.DubboLogEnum;
+import com.alipay.sofa.tracer.plugins.dubbo.stat.DubboServerStatJsonReporter;
+import com.alipay.sofa.tracer.plugins.dubbo.stat.DubboServerStatReporter;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 3:47 PM
+ * @since:
+ **/
+public class DubboProviderSofaTracer extends AbstractServerTracer {
+
+    private volatile static DubboProviderSofaTracer dubboProviderSofaTracer = null;
+
+    public static DubboProviderSofaTracer getDubboProviderSofaTracerSingleton() {
+        if (dubboProviderSofaTracer == null) {
+            synchronized (DubboProviderSofaTracer.class) {
+                if (dubboProviderSofaTracer == null) {
+                    dubboProviderSofaTracer = new DubboProviderSofaTracer(
+                        ComponentNameConstants.DUBBO_SERVER);
+                }
+            }
+        }
+        return dubboProviderSofaTracer;
+    }
+
+    public DubboProviderSofaTracer(String tracerType) {
+        super(tracerType);
+    }
+
+    @Override
+    protected String getServerDigestReporterLogName() {
+        return DubboLogEnum.DUBBO_SERVER_DIGEST.getDefaultLogName();
+    }
+
+    @Override
+    protected String getServerDigestReporterRollingKey() {
+        return DubboLogEnum.DUBBO_SERVER_DIGEST.getRollingKey();
+    }
+
+    @Override
+    protected String getServerDigestReporterLogNameKey() {
+        return DubboLogEnum.DUBBO_SERVER_DIGEST.getLogNameKey();
+    }
+
+    @Override
+    protected SpanEncoder<SofaTracerSpan> getServerDigestEncoder() {
+        if (SofaTracerConfiguration.isJsonOutput()) {
+            return new DubboServerDigestJsonEncoder();
+        } else {
+            return new DubboServerDigestEncoder();
+        }
+    }
+
+    @Override
+    protected AbstractSofaTracerStatisticReporter generateServerStatReporter() {
+        DubboLogEnum dubboClientStat = DubboLogEnum.DUBBO_SERVER_STAT;
+        String statLog = dubboClientStat.getDefaultLogName();
+        String statRollingPolicy = SofaTracerConfiguration.getRollingPolicy(dubboClientStat
+            .getRollingKey());
+        String statLogReserveConfig = SofaTracerConfiguration.getLogReserveConfig(dubboClientStat
+            .getLogNameKey());
+
+        if (SofaTracerConfiguration.isJsonOutput()) {
+            return new DubboServerStatJsonReporter(statLog, statRollingPolicy, statLogReserveConfig);
+        } else {
+            return new DubboServerStatReporter(statLog, statRollingPolicy, statLogReserveConfig);
+        }
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/DubboSofaTracerFilter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/DubboSofaTracerFilter.java
@@ -1,0 +1,586 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo26x;
+
+import com.alibaba.dubbo.common.Constants;
+import com.alibaba.dubbo.common.extension.Activate;
+import com.alibaba.dubbo.remoting.RemotingException;
+import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
+import com.alibaba.dubbo.remoting.exchange.ResponseFuture;
+import com.alibaba.dubbo.rpc.Filter;
+import com.alibaba.dubbo.rpc.Invocation;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.Result;
+import com.alibaba.dubbo.rpc.RpcContext;
+import com.alibaba.dubbo.rpc.RpcException;
+import com.alibaba.dubbo.rpc.RpcResult;
+import com.alibaba.dubbo.rpc.protocol.dubbo.FutureAdapter;
+import com.alibaba.dubbo.rpc.support.RpcUtils;
+import com.alipay.common.tracer.core.appender.self.SelfLog;
+import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
+import com.alipay.common.tracer.core.context.span.SofaTracerSpanContext;
+import com.alipay.common.tracer.core.context.trace.SofaTraceContext;
+import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
+import com.alipay.common.tracer.core.samplers.Sampler;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.LogData;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.StringUtils;
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+import com.alipay.sofa.tracer.plugins.dubbo.tracer.DubboConsumerSofaTracer;
+import com.alipay.sofa.tracer.plugins.dubbo.tracer.DubboProviderSofaTracer;
+import io.opentracing.tag.Tags;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 2:02 PM
+ * @since: 2.3.4
+ **/
+@Activate(group = { Constants.PROVIDER, Constants.CONSUMER }, value = "dubboSofaTracerFilter", order = 1)
+public class DubboSofaTracerFilter implements Filter {
+
+    private String                             appName         = StringUtils.EMPTY_STRING;
+
+    private static final String                BLANK           = StringUtils.EMPTY_STRING;
+
+    private static final String                SPAN_INVOKE_KEY = "sofa.current.span.key";
+
+    private DubboConsumerSofaTracer            dubboConsumerSofaTracer;
+
+    private DubboProviderSofaTracer            dubboProviderSofaTracer;
+
+    private static Map<String, SofaTracerSpan> TracerSpanMap   = new ConcurrentHashMap<>();
+
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+        // do not record
+        if ("$echo".equals(invocation.getMethodName())) {
+            return invoker.invoke(invocation);
+        }
+
+        RpcContext rpcContext = RpcContext.getContext();
+        // get appName
+        if (StringUtils.isBlank(this.appName)) {
+            this.appName = SofaTracerConfiguration
+                .getProperty(SofaTracerConfiguration.TRACER_APPNAME_KEY);
+        }
+        // get span kind by rpc request type
+        String spanKind = spanKind(rpcContext);
+        Result result;
+        if (spanKind.equals(Tags.SPAN_KIND_SERVER)) {
+            result = doServerFilter(invoker, invocation);
+        } else {
+            result = doClientFilter(rpcContext, invoker, invocation);
+        }
+        return result;
+    }
+
+    /**
+     * rpc client handler
+     * @param rpcContext
+     * @param invoker
+     * @param invocation
+     * @return
+     */
+    private Result doClientFilter(RpcContext rpcContext, Invoker<?> invoker, Invocation invocation) {
+        // to build tracer instance
+        if (dubboConsumerSofaTracer == null) {
+            this.dubboConsumerSofaTracer = DubboConsumerSofaTracer
+                .getDubboConsumerSofaTracerSingleton();
+        }
+        // get methodName
+        String methodName = rpcContext.getMethodName();
+        // get service interface
+        String service = invoker.getInterface().getSimpleName();
+        // build a dubbo rpc span
+        SofaTracerSpan sofaTracerSpan = dubboConsumerSofaTracer.clientSend(service + "#"
+                                                                           + methodName);
+        // set tags to span
+        appendRpcClientSpanTags(invoker, sofaTracerSpan);
+        // do serialized and then transparent transmission to the rpc server
+        String serializedSpanContext = sofaTracerSpan.getSofaTracerSpanContext()
+            .serializeSpanContext();
+        //put into attachments
+        invocation.getAttachments().put(CommonSpanTags.RPC_TRACE_NAME, serializedSpanContext);
+
+        boolean isOneWay = false, deferFinish = false;
+
+        // check invoke type
+        boolean isAsync = RpcUtils.isAsync(invoker.getUrl(), invocation);
+
+        // set invoke type tag
+        if (isAsync) {
+            sofaTracerSpan.setTag(CommonSpanTags.INVOKE_TYPE, "future");
+        } else {
+            isOneWay = RpcUtils.isOneway(invoker.getUrl(), invocation);
+            if (isOneWay) {
+                sofaTracerSpan.setTag(CommonSpanTags.INVOKE_TYPE, "oneway");
+            } else {
+                sofaTracerSpan.setTag(CommonSpanTags.INVOKE_TYPE, "sync");
+            }
+        }
+
+        Result result;
+        Throwable exception = null;
+        String resultCode = SofaTracerConstant.RESULT_CODE_SUCCESS;
+        try {
+            // do invoke
+            result = invoker.invoke(invocation);
+            if (result.hasException()) {
+                exception = result.getException();
+            }
+            // the case on async client invocation
+            Future<Object> future = rpcContext.getFuture();
+            if (future instanceof FutureAdapter) {
+                deferFinish = ensureSpanFinishes(future, invocation, invoker);
+            }
+            return result;
+        } catch (RpcException e) {
+            exception = e;
+            throw e;
+        } catch (Throwable t) {
+            exception = t;
+            throw new RpcException(t);
+        } finally {
+            if (exception != null) {
+                // finish span on exception, delay to clear tl in handleError
+                handleError(exception, null);
+            } else {
+                // sync invoke
+                if (isOneWay || !deferFinish) {
+                    dubboConsumerSofaTracer.clientReceive(resultCode);
+                } else {
+                    // to clean SofaTraceContext
+                    SofaTraceContext sofaTraceContext = SofaTraceContextHolder
+                        .getSofaTraceContext();
+                    SofaTracerSpan clientSpan = sofaTraceContext.pop();
+                    if (clientSpan != null) {
+                        // Record client send event
+                        sofaTracerSpan.log(LogData.CLIENT_SEND_EVENT_VALUE);
+                    }
+                    // cache the current span
+                    TracerSpanMap.put(getTracerSpanMapKey(invoker), sofaTracerSpan);
+                    if (clientSpan != null && clientSpan.getParentSofaTracerSpan() != null) {
+                        //restore parent
+                        sofaTraceContext.push(clientSpan.getParentSofaTracerSpan());
+                    }
+                }
+            }
+        }
+    }
+
+    boolean ensureSpanFinishes(Future<Object> future, Invocation invocation, Invoker<?> invoker) {
+        boolean deferFinish = false;
+        if (future instanceof FutureAdapter) {
+            deferFinish = true;
+            ResponseFuture original = ((FutureAdapter<Object>) future).getFuture();
+            ResponseFuture wrapped = new AsyncResponseFutureDelegate(invocation, invoker, original);
+            // Ensures even if no callback added later, for example when a consumer, we finish the span
+            wrapped.setCallback(null);
+            RpcContext.getContext().setFuture(new FutureAdapter<>(wrapped));
+        }
+        return deferFinish;
+    }
+
+    /**
+     * finish tracer under async
+     * @param result
+     * @param sofaTracerSpan
+     * @param invocation
+     */
+    public static void doFinishTracerUnderAsync(Result result, SofaTracerSpan sofaTracerSpan,
+                                                Invocation invocation) {
+        DubboConsumerSofaTracer dubboConsumerSofaTracer = DubboConsumerSofaTracer
+            .getDubboConsumerSofaTracerSingleton();
+        // to build tracer instance
+        String resultCode = SofaTracerConstant.RESULT_CODE_SUCCESS;
+        if (result.hasException()) {
+            if (result.getException() instanceof RpcException) {
+                resultCode = Integer.toString(((RpcException) result.getException()).getCode());
+                sofaTracerSpan.setTag(CommonSpanTags.RESULT_CODE, resultCode);
+            } else {
+                resultCode = SofaTracerConstant.RESULT_CODE_ERROR;
+            }
+        }
+        // add elapsed time
+        appendElapsedTimeTags(invocation, sofaTracerSpan, result, true);
+        dubboConsumerSofaTracer.clientReceiveTagFinish(sofaTracerSpan, resultCode);
+    }
+
+    /**
+     * handler when exception
+     * @param error
+     * @param span
+     */
+    private static void handleError(Throwable error, SofaTracerSpan span) {
+        String errorCode;
+        if (error instanceof RpcException) {
+            errorCode = Integer.toString(((RpcException) error).getCode());
+        } else {
+            errorCode = SofaTracerConstant.RESULT_CODE_ERROR;
+        }
+        if (span == null) {
+            SofaTracerSpan currentSpan = SofaTraceContextHolder.getSofaTraceContext()
+                .getCurrentSpan();
+            if (currentSpan != null) {
+                currentSpan.setTag(Tags.ERROR.getKey(), error.getMessage());
+                DubboConsumerSofaTracer.getDubboConsumerSofaTracerSingleton().clientReceive(
+                    errorCode);
+            }
+        } else {
+            span.setTag(Tags.ERROR.getKey(), error.getMessage());
+            DubboConsumerSofaTracer.getDubboConsumerSofaTracerSingleton().clientReceiveTagFinish(
+                span, errorCode);
+        }
+    }
+
+    /**
+     * rpc client handler
+     * @param invoker
+     * @param invocation
+     * @return
+     */
+    private Result doServerFilter(Invoker<?> invoker, Invocation invocation) {
+        if (dubboProviderSofaTracer == null) {
+            this.dubboProviderSofaTracer = DubboProviderSofaTracer
+                .getDubboProviderSofaTracerSingleton();
+        }
+        SofaTracerSpan sofaTracerSpan = serverReceived(invocation);
+        appendRpcServerSpanTags(invoker, sofaTracerSpan);
+        Result result;
+        Throwable exception = null;
+        try {
+            result = invoker.invoke(invocation);
+            if (result == null) {
+                return null;
+            } else {
+                appendElapsedTimeTags(invocation, sofaTracerSpan, result, false);
+            }
+            if (result.hasException()) {
+                exception = result.getException();
+            }
+            return result;
+        } catch (RpcException e) {
+            exception = e;
+            throw e;
+        } catch (Throwable t) {
+            exception = t;
+            throw new RpcException(t);
+        } finally {
+            String resultCode = SofaTracerConstant.RESULT_CODE_SUCCESS;
+            if (exception != null) {
+                if (exception instanceof RpcException) {
+                    sofaTracerSpan.setTag(Tags.ERROR.getKey(), exception.getMessage());
+                    RpcException rpcException = (RpcException) exception;
+                    if (rpcException.isBiz()) {
+                        resultCode = String.valueOf(rpcException.getCode());
+                    }
+                } else {
+                    resultCode = SofaTracerConstant.RESULT_CODE_ERROR;
+                }
+            }
+            dubboProviderSofaTracer.serverSend(resultCode);
+        }
+    }
+
+    /**
+     * dubbo server receive request
+     * @param invocation
+     * @return
+     */
+    private SofaTracerSpan serverReceived(Invocation invocation) {
+        Map<String, String> tags = new HashMap<>();
+        tags.put(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+        String serializeSpanContext = invocation.getAttachments()
+            .get(CommonSpanTags.RPC_TRACE_NAME);
+        SofaTracerSpanContext sofaTracerSpanContext = SofaTracerSpanContext
+            .deserializeFromString(serializeSpanContext);
+        boolean isCalculateSampler = false;
+        boolean isSampled = true;
+        if (sofaTracerSpanContext == null) {
+            SelfLog
+                .error("SpanContext created error when server received and root SpanContext created.");
+            sofaTracerSpanContext = SofaTracerSpanContext.rootStart();
+            isCalculateSampler = true;
+        }
+        String simpleName = invocation.getInvoker().getInterface().getSimpleName();
+        SofaTracerSpan serverSpan = new SofaTracerSpan(dubboProviderSofaTracer.getSofaTracer(),
+            System.currentTimeMillis(), simpleName, sofaTracerSpanContext, tags);
+        // calculate sampler
+        if (isCalculateSampler) {
+            Sampler sampler = dubboProviderSofaTracer.getSofaTracer().getSampler();
+            if (sampler != null) {
+                isSampled = sampler.sample(serverSpan).isSampled();
+            }
+            sofaTracerSpanContext.setSampled(isSampled);
+        }
+        SofaTraceContext sofaTraceContext = SofaTraceContextHolder.getSofaTraceContext();
+        // Record server receive event
+        serverSpan.log(LogData.SERVER_RECV_EVENT_VALUE);
+        sofaTraceContext.push(serverSpan);
+        return serverSpan;
+    }
+
+    /**
+     * append tag
+     * @param invocation
+     * @param sofaTracerSpan
+     * @param result
+     * @param isClient
+     */
+    private static void appendElapsedTimeTags(Invocation invocation, SofaTracerSpan sofaTracerSpan,
+                                              Result result, boolean isClient) {
+        if (sofaTracerSpan == null) {
+            return;
+        }
+        String reqSize;
+        String respSize;
+        String elapsed;
+        String deElapsed;
+        if (isClient) {
+            reqSize = invocation.getAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE);
+            elapsed = invocation.getAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME);
+            respSize = result.getAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE);
+            deElapsed = result.getAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME);
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME,
+                parseAttachment(elapsed, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME,
+                parseAttachment(deElapsed, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE,
+                parseAttachment(reqSize, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE,
+                parseAttachment(respSize, 0));
+        } else {
+            reqSize = invocation.getAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE);
+            deElapsed = invocation.getAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME);
+            respSize = result.getAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE);
+            elapsed = result.getAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_TIME);
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE,
+                parseAttachment(reqSize, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME,
+                parseAttachment(deElapsed, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE,
+                parseAttachment(respSize, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_SERIALIZE_TIME,
+                parseAttachment(elapsed, 0));
+        }
+
+    }
+
+    /**
+     * parse dubbo attachment
+     * @param value
+     * @param defaultVal
+     * @return
+     */
+    private static int parseAttachment(String value, int defaultVal) {
+        try {
+            if (StringUtils.isNotBlank(value)) {
+                defaultVal = Integer.parseInt(value);
+            }
+        } catch (Exception e) {
+            SelfLog.error("Failed to parse Dubbo plugin params.", e);
+        }
+        return defaultVal;
+    }
+
+    /**
+     * set rpc server span tags
+     * @param invoker
+     * @param sofaTracerSpan
+     */
+    private void appendRpcServerSpanTags(Invoker<?> invoker, SofaTracerSpan sofaTracerSpan) {
+        if (sofaTracerSpan == null) {
+            return;
+        }
+        RpcContext rpcContext = RpcContext.getContext();
+        Map<String, String> tagsStr = sofaTracerSpan.getTagsWithStr();
+        tagsStr.put(Tags.SPAN_KIND.getKey(), spanKind(rpcContext));
+        String service = invoker.getInterface().getName();
+        tagsStr.put(CommonSpanTags.SERVICE, service == null ? BLANK : service);
+        String methodName = rpcContext.getMethodName();
+        tagsStr.put(CommonSpanTags.METHOD, methodName == null ? BLANK : methodName);
+        String app = rpcContext.getUrl().getParameter(Constants.APPLICATION_KEY);
+        tagsStr.put(CommonSpanTags.REMOTE_HOST, rpcContext.getRemoteHost());
+        tagsStr.put(CommonSpanTags.LOCAL_APP, app == null ? BLANK : app);
+        tagsStr.put(CommonSpanTags.CURRENT_THREAD_NAME, Thread.currentThread().getName());
+        String protocol = rpcContext.getUrl().getProtocol();
+        tagsStr.put(CommonSpanTags.PROTOCOL, protocol == null ? BLANK : protocol);
+        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getRemoteHost());
+        tagsStr.put(CommonSpanTags.LOCAL_PORT, String.valueOf(rpcContext.getRemotePort()));
+    }
+
+    /**
+     * set rpc client span tags
+     * @param invoker
+     * @param sofaTracerSpan
+     */
+    private void appendRpcClientSpanTags(Invoker<?> invoker, SofaTracerSpan sofaTracerSpan) {
+        if (sofaTracerSpan == null) {
+            return;
+        }
+        RpcContext rpcContext = RpcContext.getContext();
+        Map<String, String> tagsStr = sofaTracerSpan.getTagsWithStr();
+        tagsStr.put(Tags.SPAN_KIND.getKey(), spanKind(rpcContext));
+        String protocol = rpcContext.getUrl().getProtocol();
+        tagsStr.put(CommonSpanTags.PROTOCOL, protocol == null ? BLANK : protocol);
+        String service = invoker.getInterface().getName();
+        tagsStr.put(CommonSpanTags.SERVICE, service == null ? BLANK : service);
+        String methodName = rpcContext.getMethodName();
+        tagsStr.put(CommonSpanTags.METHOD, methodName == null ? BLANK : methodName);
+        tagsStr.put(CommonSpanTags.CURRENT_THREAD_NAME, Thread.currentThread().getName());
+        String app = rpcContext.getUrl().getParameter(Constants.APPLICATION_KEY);
+        tagsStr.put(CommonSpanTags.LOCAL_APP, app == null ? BLANK : app);
+        tagsStr.put(CommonSpanTags.REMOTE_HOST, rpcContext.getRemoteHost());
+        tagsStr.put(CommonSpanTags.REMOTE_PORT, String.valueOf(rpcContext.getRemotePort()));
+        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getLocalHost());
+    }
+
+    private String spanKind(RpcContext rpcContext) {
+        return rpcContext.isConsumerSide() ? Tags.SPAN_KIND_CLIENT : Tags.SPAN_KIND_SERVER;
+    }
+
+    private static String getTracerSpanMapKey(Invoker<?> invoker) {
+        return SPAN_INVOKE_KEY + "." + invoker.hashCode();
+    }
+
+    private static SofaTracerSpan getAndClearTracerSpanMap(String spanKey) {
+        // clean TracerSpanMap
+        if (TracerSpanMap.containsKey(spanKey)) {
+            return TracerSpanMap.remove(spanKey);
+        }
+        return null;
+    }
+
+    /**
+     * ResponseFuture Delegate Class to Resolve ResponseCallBack are covered
+     */
+    public class AsyncResponseFutureDelegate implements ResponseFuture {
+
+        private final ResponseFuture responseFuture;
+        private final Invocation     invocation;
+        private final Invoker<?>     invoker;
+
+        public AsyncResponseFutureDelegate(Invocation invocation, Invoker<?> invoker,
+                                           ResponseFuture responseFuture) {
+            this.responseFuture = responseFuture;
+            this.invocation = invocation;
+            this.invoker = invoker;
+        }
+
+        @Override
+        public Object get() throws RemotingException {
+            return responseFuture.get();
+        }
+
+        @Override
+        public Object get(int timeoutInMillis) throws RemotingException {
+            return responseFuture.get(timeoutInMillis);
+        }
+
+        @Override
+        public void setCallback(ResponseCallback callback) {
+            ResponseCallback delegate = TracingResponseCallback.create(callback, invocation,
+                invoker);
+            responseFuture.setCallback(delegate);
+        }
+
+        @Override
+        public boolean isDone() {
+            return responseFuture.isDone();
+        }
+    }
+
+    static class TracingResponseCallback {
+
+        static ResponseCallback create(ResponseCallback delegate, Invocation invocation,
+                                       Invoker<?> invoker) {
+            if (delegate == null) {
+                return new FinishSpan(invocation, invoker);
+            }
+            return new DelegateAndFinishSpan(delegate, invocation, invoker);
+        }
+
+        static class FinishSpan implements ResponseCallback {
+
+            final Invocation invocation;
+            final Invoker    invoker;
+
+            FinishSpan(Invocation invocation, Invoker invoker) {
+                this.invocation = invocation;
+                this.invoker = invoker;
+            }
+
+            @Override
+            public void done(Object response) {
+                String spanKey = getTracerSpanMapKey(invoker);
+                // get and clear cache map
+                SofaTracerSpan sofaSpan = getAndClearTracerSpanMap(spanKey);
+                if (response instanceof RpcResult && sofaSpan != null) {
+                    // add elapsed time
+                    doFinishTracerUnderAsync((RpcResult) response, sofaSpan, invocation);
+                } else {
+                    SelfLog.warn("Dubbo async invoke call back response type is " + response
+                                 + " or span is null, current key is " + spanKey);
+                }
+            }
+
+            @Override
+            public void caught(Throwable throwable) {
+                String spanKey = getTracerSpanMapKey(invoker);
+                // get and clear cache map
+                SofaTracerSpan sofaSpan = getAndClearTracerSpanMap(spanKey);
+                if (sofaSpan != null) {
+                    handleError(throwable, sofaSpan);
+                }
+            }
+        }
+
+        static final class DelegateAndFinishSpan extends FinishSpan {
+
+            final ResponseCallback origin;
+
+            DelegateAndFinishSpan(ResponseCallback origin, Invocation invocation, Invoker invoker) {
+                super(invocation, invoker);
+                this.origin = origin;
+            }
+
+            @Override
+            public void done(Object response) {
+                try {
+                    origin.done(response);
+                } finally {
+                    super.done(response);
+                }
+            }
+
+            @Override
+            public void caught(Throwable exception) {
+                try {
+                    origin.caught(exception);
+                } finally {
+                    super.caught(exception);
+                }
+            }
+        }
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/DubboSofaTracerFilter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/DubboSofaTracerFilter.java
@@ -55,7 +55,7 @@ import java.util.concurrent.Future;
  * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 2:02 PM
  * @since: 2.3.4
  **/
-@Activate(group = { Constants.PROVIDER, Constants.CONSUMER }, value = "dubboSofaTracerFilter", order = 1)
+@Activate(group = { Constants.PROVIDER, Constants.CONSUMER }, order = 1)
 public class DubboSofaTracerFilter implements Filter {
 
     private String                             appName         = StringUtils.EMPTY_STRING;

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/DubboSofaTracerFilter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/DubboSofaTracerFilter.java
@@ -425,8 +425,8 @@ public class DubboSofaTracerFilter implements Filter {
         tagsStr.put(CommonSpanTags.CURRENT_THREAD_NAME, Thread.currentThread().getName());
         String protocol = rpcContext.getUrl().getProtocol();
         tagsStr.put(CommonSpanTags.PROTOCOL, protocol == null ? BLANK : protocol);
-        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getRemoteHost());
-        tagsStr.put(CommonSpanTags.LOCAL_PORT, String.valueOf(rpcContext.getRemotePort()));
+        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getLocalHost());
+        tagsStr.put(CommonSpanTags.LOCAL_PORT, String.valueOf(rpcContext.getLocalPort()));
     }
 
     /**

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/wrapper/DataSizeCodecWrapper.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo26x/wrapper/DataSizeCodecWrapper.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo26x.wrapper;
+
+import com.alibaba.dubbo.remoting.Channel;
+import com.alibaba.dubbo.remoting.Codec2;
+import com.alibaba.dubbo.remoting.buffer.ChannelBuffer;
+import com.alibaba.dubbo.remoting.exchange.Request;
+import com.alibaba.dubbo.remoting.exchange.Response;
+import com.alibaba.dubbo.rpc.RpcInvocation;
+import com.alibaba.dubbo.rpc.RpcResult;
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+
+import java.io.IOException;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 7:46 PM
+ * @since:
+ **/
+public class DataSizeCodecWrapper implements Codec2 {
+    /**
+     * origin codec
+     */
+    protected Codec2 codec;
+
+    public DataSizeCodecWrapper(Codec2 codec) {
+        this.codec = codec;
+    }
+
+    @Override
+    public void encode(Channel channel, ChannelBuffer buffer, Object message) throws IOException {
+        if (message instanceof Request) {
+            Object data = ((Request) message).getData();
+            if (data instanceof RpcInvocation) {
+                RpcInvocation invocation = (RpcInvocation) data;
+                encodeRequestWithTracer(channel, buffer, message, invocation);
+                return;
+            }
+        } else if (message instanceof Response) {
+            Object response = ((Response) message).getResult();
+            if (response instanceof RpcResult) {
+                encodeResultWithTracer(channel, buffer, message);
+                return;
+            }
+        }
+        codec.encode(channel, buffer, message);
+    }
+
+    /**
+     * @param channel       a long connection
+     * @param buffer        buffer
+     * @param message       the original Request object
+     * @param invocation    Invocation in Request
+     * @throws IOException  serialization exception
+     */
+    protected void encodeRequestWithTracer(Channel channel, ChannelBuffer buffer, Object message,
+                                           RpcInvocation invocation) throws IOException {
+        long startTime = System.currentTimeMillis();
+        int index = buffer.writerIndex();
+        // serialization
+        codec.encode(channel, buffer, message);
+        int reqSize = buffer.writerIndex() - index;
+        long elapsed = System.currentTimeMillis() - startTime;
+        invocation.setAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE,
+            String.valueOf(reqSize));
+        invocation.setAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME,
+            String.valueOf(elapsed));
+    }
+
+    /**
+     * @param channel       a long connection
+     * @param buffer        buffer
+     * @param message        the original Request object
+     * @throws IOException  serialization exception
+     */
+    protected void encodeResultWithTracer(Channel channel, ChannelBuffer buffer, Object message)
+                                                                                                throws IOException {
+        Object result = ((Response) message).getResult();
+        long startTime = System.currentTimeMillis();
+        int index = buffer.writerIndex();
+        codec.encode(channel, buffer, message);
+        int respSize = buffer.writerIndex() - index;
+        long elapsed = System.currentTimeMillis() - startTime;
+        ((RpcResult) result).setAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE,
+            String.valueOf(respSize));
+        ((RpcResult) result).setAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_TIME,
+            String.valueOf(elapsed));
+    }
+
+    /**
+     * deserialization operation
+     * @param channel
+     * @param input
+     * @return
+     * @throws IOException
+     */
+    @Override
+    public Object decode(Channel channel, ChannelBuffer input) throws IOException {
+        long startTime = System.currentTimeMillis();
+        int index = input.readerIndex();
+        Object ret = codec.decode(channel, input);
+        int size = input.readerIndex() - index;
+        long elapsed = System.currentTimeMillis() - startTime;
+        if (ret instanceof Request) {
+            // server-side deserialize the Request
+            Object data = ((Request) ret).getData();
+            if (data instanceof RpcInvocation) {
+                RpcInvocation invocation = (RpcInvocation) data;
+                invocation.setAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE,
+                    String.valueOf(size));
+                invocation.setAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME,
+                    String.valueOf(elapsed));
+            }
+        } else if (ret instanceof Response) {
+            // client-side deserialize the Response
+            Object result = ((Response) ret).getResult();
+            if (result instanceof RpcResult) {
+                RpcResult rpcResult = (RpcResult) result;
+                rpcResult.setAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE,
+                    String.valueOf(size));
+                rpcResult.setAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME,
+                    String.valueOf(elapsed));
+            }
+        }
+        return ret;
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/DubboSofaTracerFilter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/DubboSofaTracerFilter.java
@@ -51,7 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 2:02 PM
  * @since: 2.3.4
  **/
-@Activate(group = { CommonConstants.PROVIDER, CommonConstants.CONSUMER }, value = "dubboSofaTracerFilter", order = 1)
+@Activate(group = { CommonConstants.PROVIDER, CommonConstants.CONSUMER }, order = 1)
 public class DubboSofaTracerFilter implements Filter {
 
     private String                             appName         = StringUtils.EMPTY_STRING;

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/DubboSofaTracerFilter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/DubboSofaTracerFilter.java
@@ -382,8 +382,8 @@ public class DubboSofaTracerFilter implements Filter {
         tagsStr.put(CommonSpanTags.CURRENT_THREAD_NAME, Thread.currentThread().getName());
         String protocol = rpcContext.getUrl().getProtocol();
         tagsStr.put(CommonSpanTags.PROTOCOL, protocol == null ? BLANK : protocol);
-        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getRemoteHost());
-        tagsStr.put(CommonSpanTags.LOCAL_PORT, String.valueOf(rpcContext.getRemotePort()));
+        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getLocalHost());
+        tagsStr.put(CommonSpanTags.LOCAL_PORT, String.valueOf(rpcContext.getLocalPort()));
     }
 
     private void appendRpcClientSpanTags(Invoker<?> invoker, SofaTracerSpan sofaTracerSpan) {

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/DubboSofaTracerFilter.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/DubboSofaTracerFilter.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo27x;
+
+import com.alipay.common.tracer.core.appender.self.SelfLog;
+import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
+import com.alipay.common.tracer.core.context.span.SofaTracerSpanContext;
+import com.alipay.common.tracer.core.context.trace.SofaTraceContext;
+import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
+import com.alipay.common.tracer.core.samplers.Sampler;
+import com.alipay.common.tracer.core.span.CommonSpanTags;
+import com.alipay.common.tracer.core.span.LogData;
+import com.alipay.common.tracer.core.span.SofaTracerSpan;
+import com.alipay.common.tracer.core.utils.StringUtils;
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+import com.alipay.sofa.tracer.plugins.dubbo.tracer.DubboConsumerSofaTracer;
+import com.alipay.sofa.tracer.plugins.dubbo.tracer.DubboProviderSofaTracer;
+import io.opentracing.tag.Tags;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.remoting.TimeoutException;
+import org.apache.dubbo.rpc.Filter;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.support.RpcUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 2:02 PM
+ * @since: 2.3.4
+ **/
+@Activate(group = { CommonConstants.PROVIDER, CommonConstants.CONSUMER }, value = "dubboSofaTracerFilter", order = 1)
+public class DubboSofaTracerFilter implements Filter {
+
+    private String                             appName         = StringUtils.EMPTY_STRING;
+
+    private static final String                BLANK           = StringUtils.EMPTY_STRING;
+
+    private static final String                SPAN_INVOKE_KEY = "sofa.current.span.key";
+
+    private DubboConsumerSofaTracer            dubboConsumerSofaTracer;
+
+    private DubboProviderSofaTracer            dubboProviderSofaTracer;
+
+    private static Map<String, SofaTracerSpan> TracerSpanMap   = new ConcurrentHashMap<String, SofaTracerSpan>();
+
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+        // do not record
+        if ("$echo".equals(invocation.getMethodName())) {
+            return invoker.invoke(invocation);
+        }
+
+        RpcContext rpcContext = RpcContext.getContext();
+        // get appName
+        if (StringUtils.isBlank(this.appName)) {
+            this.appName = SofaTracerConfiguration
+                .getProperty(SofaTracerConfiguration.TRACER_APPNAME_KEY);
+        }
+        // get span kind by rpc request type
+        String spanKind = spanKind(rpcContext);
+        Result result;
+        if (spanKind.equals(Tags.SPAN_KIND_SERVER)) {
+            result = doServerFilter(invoker, invocation);
+        } else {
+            result = doClientFilter(rpcContext, invoker, invocation);
+        }
+        return result;
+    }
+
+    @Override
+    public Result onResponse(Result result, Invoker<?> invoker, Invocation invocation) {
+        String spanKey = getTracerSpanMapKey(invoker);
+        try {
+            // only the asynchronous callback to print
+            boolean isAsync = RpcUtils.isAsync(invoker.getUrl(), invocation);
+            if (!isAsync) {
+                return result;
+            }
+            if (TracerSpanMap.containsKey(spanKey)) {
+                SofaTracerSpan sofaTracerSpan = TracerSpanMap.get(spanKey);
+                // to build tracer instance
+                if (dubboConsumerSofaTracer == null) {
+                    this.dubboConsumerSofaTracer = DubboConsumerSofaTracer
+                        .getDubboConsumerSofaTracerSingleton();
+                }
+                String resultCode = SofaTracerConstant.RESULT_CODE_SUCCESS;
+                if (result.hasException()) {
+                    if (result.getException() instanceof RpcException) {
+                        resultCode = Integer.toString(((RpcException) result.getException())
+                            .getCode());
+                        sofaTracerSpan.setTag(CommonSpanTags.RESULT_CODE, resultCode);
+                    } else {
+                        resultCode = SofaTracerConstant.RESULT_CODE_ERROR;
+                    }
+                }
+                // add elapsed time
+                appendElapsedTimeTags(invocation, sofaTracerSpan, result, true);
+                dubboConsumerSofaTracer.clientReceiveTagFinish(sofaTracerSpan, resultCode);
+            }
+        } finally {
+            if (TracerSpanMap.containsKey(spanKey)) {
+                TracerSpanMap.remove(spanKey);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * rpc client handler
+     * @param rpcContext
+     * @param invoker
+     * @param invocation
+     * @return
+     */
+    private Result doClientFilter(RpcContext rpcContext, Invoker<?> invoker, Invocation invocation) {
+        // to build tracer instance
+        if (dubboConsumerSofaTracer == null) {
+            this.dubboConsumerSofaTracer = DubboConsumerSofaTracer
+                .getDubboConsumerSofaTracerSingleton();
+        }
+        // get methodName
+        String methodName = rpcContext.getMethodName();
+        // get service interface
+        String service = invoker.getInterface().getSimpleName();
+        // build a dubbo rpc span
+        SofaTracerSpan sofaTracerSpan = dubboConsumerSofaTracer.clientSend(service + "#"
+                                                                           + methodName);
+        // set tags to span
+        appendRpcClientSpanTags(invoker, sofaTracerSpan);
+        // do serialized and then transparent transmission to the rpc server
+        String serializedSpanContext = sofaTracerSpan.getSofaTracerSpanContext()
+            .serializeSpanContext();
+        //put into attachments
+        invocation.getAttachments().put(CommonSpanTags.RPC_TRACE_NAME, serializedSpanContext);
+        // check invoke type
+        boolean isAsync = RpcUtils.isAsync(invoker.getUrl(), invocation);
+        boolean isOneWay = false;
+        if (isAsync) {
+            sofaTracerSpan.setTag(CommonSpanTags.INVOKE_TYPE, "future");
+        } else {
+            isOneWay = RpcUtils.isOneway(invoker.getUrl(), invocation);
+            if (isOneWay) {
+                sofaTracerSpan.setTag(CommonSpanTags.INVOKE_TYPE, "oneway");
+            } else {
+                sofaTracerSpan.setTag(CommonSpanTags.INVOKE_TYPE, "sync");
+            }
+        }
+        Result result;
+        Throwable exception = null;
+        String resultCode = SofaTracerConstant.RESULT_CODE_SUCCESS;
+        try {
+            // do invoke
+            result = invoker.invoke(invocation);
+            // check result
+            if (result == null) {
+                // isOneWay, we think that the current request is successful
+                if (isOneWay) {
+                    sofaTracerSpan.setTag(CommonSpanTags.RESP_SIZE, 0);
+                }
+            } else {
+                // add elapsed time
+                appendElapsedTimeTags(invocation, sofaTracerSpan, result,true);
+            }
+        } catch (RpcException e) {
+            exception = e;
+            throw e;
+        } catch (Throwable t) {
+            exception = t;
+            throw new RpcException(t);
+        } finally {
+            if (exception != null) {
+                if (exception instanceof RpcException) {
+                    sofaTracerSpan.setTag(Tags.ERROR.getKey(),exception.getMessage());
+                    RpcException rpcException = (RpcException) exception;
+                    resultCode = String.valueOf(rpcException.getCode());
+                } else {
+                    resultCode = SofaTracerConstant.RESULT_CODE_ERROR;
+                }
+            }
+
+            if (!isAsync) {
+                dubboConsumerSofaTracer.clientReceive(resultCode);
+            } else {
+                SofaTraceContext sofaTraceContext = SofaTraceContextHolder.getSofaTraceContext();
+                SofaTracerSpan clientSpan = sofaTraceContext.pop();
+                if (clientSpan != null) {
+                    // Record client send event
+                    sofaTracerSpan.log(LogData.CLIENT_SEND_EVENT_VALUE);
+                }
+                // cache the current span
+                TracerSpanMap.put(getTracerSpanMapKey(invoker), sofaTracerSpan);
+                if (clientSpan != null && clientSpan.getParentSofaTracerSpan() != null) {
+                    //restore parent
+                    sofaTraceContext.push(clientSpan.getParentSofaTracerSpan());
+                }
+                CompletableFuture<Object> future = (CompletableFuture<Object>) RpcContext.getContext().getFuture();
+                future.whenComplete((object, throwable)-> {
+                    if (throwable != null && throwable instanceof TimeoutException) {
+                        sofaTracerSpan.setTag(Tags.ERROR.getKey(),throwable.getMessage());
+                        dubboConsumerSofaTracer.clientReceiveTagFinish(sofaTracerSpan, "03");
+                    }
+                });
+            }
+        }
+        return result;
+    }
+
+    /**
+     * rpc client handler
+     * @param invoker
+     * @param invocation
+     * @return
+     */
+    private Result doServerFilter(Invoker<?> invoker, Invocation invocation) {
+        if (dubboProviderSofaTracer == null) {
+            this.dubboProviderSofaTracer = DubboProviderSofaTracer
+                .getDubboProviderSofaTracerSingleton();
+        }
+        SofaTracerSpan sofaTracerSpan = serverReceived(invocation);
+        appendRpcServerSpanTags(invoker, sofaTracerSpan);
+        Result result;
+        Throwable exception = null;
+        try {
+            result = invoker.invoke(invocation);
+            if (result == null) {
+                return null;
+            } else {
+                appendElapsedTimeTags(invocation, sofaTracerSpan, result, false);
+            }
+            if (result.hasException()) {
+                exception = result.getException();
+            }
+            return result;
+        } catch (RpcException e) {
+            exception = e;
+            throw e;
+        } catch (Throwable t) {
+            exception = t;
+            throw new RpcException(t);
+        } finally {
+            String resultCode = SofaTracerConstant.RESULT_CODE_SUCCESS;
+            if (exception != null) {
+                if (exception instanceof RpcException) {
+                    sofaTracerSpan.setTag(Tags.ERROR.getKey(), exception.getMessage());
+                    RpcException rpcException = (RpcException) exception;
+                    if (rpcException.isBiz()) {
+                        resultCode = String.valueOf(rpcException.getCode());
+                    }
+                } else {
+                    resultCode = SofaTracerConstant.RESULT_CODE_ERROR;
+                }
+            }
+            dubboProviderSofaTracer.serverSend(resultCode);
+        }
+    }
+
+    private SofaTracerSpan serverReceived(Invocation invocation) {
+        Map<String, String> tags = new HashMap<>();
+        tags.put(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
+        String serializeSpanContext = invocation.getAttachments()
+            .get(CommonSpanTags.RPC_TRACE_NAME);
+        SofaTracerSpanContext sofaTracerSpanContext = SofaTracerSpanContext
+            .deserializeFromString(serializeSpanContext);
+        boolean isCalculateSampler = false;
+        boolean isSampled = true;
+        if (sofaTracerSpanContext == null) {
+            SelfLog
+                .error("SpanContext created error when server received and root SpanContext created.");
+            sofaTracerSpanContext = SofaTracerSpanContext.rootStart();
+            isCalculateSampler = true;
+        }
+        String simpleName = invocation.getInvoker().getInterface().getSimpleName();
+        SofaTracerSpan serverSpan = new SofaTracerSpan(dubboProviderSofaTracer.getSofaTracer(),
+            System.currentTimeMillis(), simpleName, sofaTracerSpanContext, tags);
+        // calculate sampler
+        if (isCalculateSampler) {
+            Sampler sampler = dubboProviderSofaTracer.getSofaTracer().getSampler();
+            if (sampler != null) {
+                isSampled = sampler.sample(serverSpan).isSampled();
+            }
+            sofaTracerSpanContext.setSampled(isSampled);
+        }
+        SofaTraceContext sofaTraceContext = SofaTraceContextHolder.getSofaTraceContext();
+        // Record server receive event
+        serverSpan.log(LogData.SERVER_RECV_EVENT_VALUE);
+        sofaTraceContext.push(serverSpan);
+        return serverSpan;
+    }
+
+    private void appendElapsedTimeTags(Invocation invocation, SofaTracerSpan sofaTracerSpan,
+                                       Result result, boolean isClient) {
+        if (sofaTracerSpan == null) {
+            return;
+        }
+        String reqSize;
+        String respSize;
+        String elapsed;
+        String deElapsed;
+        if (isClient) {
+            reqSize = invocation.getAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE);
+            elapsed = invocation.getAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME);
+            respSize = result.getAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE);
+            deElapsed = result.getAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME);
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME,
+                parseAttachment(elapsed, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME,
+                parseAttachment(deElapsed, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE,
+                parseAttachment(reqSize, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE,
+                parseAttachment(respSize, 0));
+        } else {
+            reqSize = invocation.getAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE);
+            deElapsed = invocation.getAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME);
+            respSize = result.getAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE);
+            elapsed = result.getAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_TIME);
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE,
+                parseAttachment(reqSize, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME,
+                parseAttachment(deElapsed, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE,
+                parseAttachment(respSize, 0));
+            sofaTracerSpan.setTag(AttachmentKeyConstants.SERVER_SERIALIZE_TIME,
+                parseAttachment(elapsed, 0));
+        }
+
+    }
+
+    private int parseAttachment(String value, int defaultVal) {
+        try {
+            if (StringUtils.isNotBlank(value)) {
+                defaultVal = Integer.parseInt(value);
+            }
+        } catch (Exception e) {
+            SelfLog.error("Failed to parse Dubbo plugin params.", e);
+        }
+        return defaultVal;
+    }
+
+    /**
+     * set rpc server span tags
+     * @param invoker
+     * @param sofaTracerSpan
+     */
+    private void appendRpcServerSpanTags(Invoker<?> invoker, SofaTracerSpan sofaTracerSpan) {
+        if (sofaTracerSpan == null) {
+            return;
+        }
+        RpcContext rpcContext = RpcContext.getContext();
+        Map<String, String> tagsStr = sofaTracerSpan.getTagsWithStr();
+        tagsStr.put(Tags.SPAN_KIND.getKey(), spanKind(rpcContext));
+        String service = invoker.getInterface().getName();
+        tagsStr.put(CommonSpanTags.SERVICE, service == null ? BLANK : service);
+        String methodName = rpcContext.getMethodName();
+        tagsStr.put(CommonSpanTags.METHOD, methodName == null ? BLANK : methodName);
+        String app = rpcContext.getUrl().getParameter(CommonConstants.APPLICATION_KEY);
+        tagsStr.put(CommonSpanTags.REMOTE_HOST, rpcContext.getRemoteHost());
+        tagsStr.put(CommonSpanTags.LOCAL_APP, app == null ? BLANK : app);
+        tagsStr.put(CommonSpanTags.CURRENT_THREAD_NAME, Thread.currentThread().getName());
+        String protocol = rpcContext.getUrl().getProtocol();
+        tagsStr.put(CommonSpanTags.PROTOCOL, protocol == null ? BLANK : protocol);
+        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getRemoteHost());
+        tagsStr.put(CommonSpanTags.LOCAL_PORT, String.valueOf(rpcContext.getRemotePort()));
+    }
+
+    private void appendRpcClientSpanTags(Invoker<?> invoker, SofaTracerSpan sofaTracerSpan) {
+        if (sofaTracerSpan == null) {
+            return;
+        }
+        RpcContext rpcContext = RpcContext.getContext();
+        Map<String, String> tagsStr = sofaTracerSpan.getTagsWithStr();
+        tagsStr.put(Tags.SPAN_KIND.getKey(), spanKind(rpcContext));
+        String protocol = rpcContext.getUrl().getProtocol();
+        tagsStr.put(CommonSpanTags.PROTOCOL, protocol == null ? BLANK : protocol);
+        String service = invoker.getInterface().getName();
+        tagsStr.put(CommonSpanTags.SERVICE, service == null ? BLANK : service);
+        String methodName = rpcContext.getMethodName();
+        tagsStr.put(CommonSpanTags.METHOD, methodName == null ? BLANK : methodName);
+        tagsStr.put(CommonSpanTags.CURRENT_THREAD_NAME, Thread.currentThread().getName());
+        String app = rpcContext.getUrl().getParameter(CommonConstants.APPLICATION_KEY);
+        tagsStr.put(CommonSpanTags.LOCAL_APP, app == null ? BLANK : app);
+        tagsStr.put(CommonSpanTags.REMOTE_HOST, rpcContext.getRemoteHost());
+        tagsStr.put(CommonSpanTags.REMOTE_PORT, String.valueOf(rpcContext.getRemotePort()));
+        tagsStr.put(CommonSpanTags.LOCAL_HOST, rpcContext.getLocalHost());
+    }
+
+    private String spanKind(RpcContext rpcContext) {
+        return rpcContext.isConsumerSide() ? Tags.SPAN_KIND_CLIENT : Tags.SPAN_KIND_SERVER;
+    }
+
+    private String getTracerSpanMapKey(Invoker<?> invoker) {
+        return SPAN_INVOKE_KEY + "." + invoker.hashCode();
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/wrapper/DataSizeCodecWrapper.java
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/java/com/alipay/sofa/tracer/plugins/dubbo27x/wrapper/DataSizeCodecWrapper.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.tracer.plugins.dubbo27x.wrapper;
+
+import com.alipay.sofa.tracer.plugins.dubbo.constants.AttachmentKeyConstants;
+import org.apache.dubbo.remoting.Channel;
+import org.apache.dubbo.remoting.Codec2;
+import org.apache.dubbo.remoting.buffer.ChannelBuffer;
+import org.apache.dubbo.remoting.exchange.Request;
+import org.apache.dubbo.remoting.exchange.Response;
+import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.RpcInvocation;
+
+import java.io.IOException;
+
+/**
+ * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/2/26 7:46 PM
+ * @since:
+ **/
+public class DataSizeCodecWrapper implements Codec2 {
+    /**
+     * origin codec
+     */
+    protected Codec2 codec;
+
+    public DataSizeCodecWrapper(Codec2 codec) {
+        this.codec = codec;
+    }
+
+    @Override
+    public void encode(Channel channel, ChannelBuffer buffer, Object message) throws IOException {
+        if (message instanceof Request) {
+            Object data = ((Request) message).getData();
+            if (data instanceof RpcInvocation) {
+                RpcInvocation invocation = (RpcInvocation) data;
+                encodeRequestWithTracer(channel, buffer, message, invocation);
+                return;
+            }
+        } else if (message instanceof Response) {
+            Object response = ((Response) message).getResult();
+            if (response instanceof AppResponse) {
+                encodeResultWithTracer(channel, buffer, message);
+                return;
+            }
+        }
+        codec.encode(channel, buffer, message);
+    }
+
+    /**
+     * @param channel       a long connection
+     * @param buffer        buffer
+     * @param message       the original Request object
+     * @param invocation    Invocation in Request
+     * @throws IOException  serialization exception
+     */
+    protected void encodeRequestWithTracer(Channel channel, ChannelBuffer buffer, Object message,
+                                           RpcInvocation invocation) throws IOException {
+        long startTime = System.currentTimeMillis();
+        int index = buffer.writerIndex();
+        // serialization
+        codec.encode(channel, buffer, message);
+        int reqSize = buffer.writerIndex() - index;
+        long elapsed = System.currentTimeMillis() - startTime;
+        invocation.setAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_SIZE,
+            String.valueOf(reqSize));
+        invocation.setAttachment(AttachmentKeyConstants.CLIENT_SERIALIZE_TIME,
+            String.valueOf(elapsed));
+    }
+
+    /**
+     * @param channel       a long connection
+     * @param buffer        buffer
+     * @param message        the original Request object
+     * @throws IOException  serialization exception
+     */
+    protected void encodeResultWithTracer(Channel channel, ChannelBuffer buffer, Object message)
+                                                                                                throws IOException {
+        Object result = ((Response) message).getResult();
+        long startTime = System.currentTimeMillis();
+        int index = buffer.writerIndex();
+        codec.encode(channel, buffer, message);
+        int respSize = buffer.writerIndex() - index;
+        long elapsed = System.currentTimeMillis() - startTime;
+        ((AppResponse) result).setAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_SIZE,
+            String.valueOf(respSize));
+        ((AppResponse) result).setAttachment(AttachmentKeyConstants.SERVER_SERIALIZE_TIME,
+            String.valueOf(elapsed));
+    }
+
+    /**
+     * deserialization operation
+     * @param channel
+     * @param input
+     * @return
+     * @throws IOException
+     */
+    @Override
+    public Object decode(Channel channel, ChannelBuffer input) throws IOException {
+        long startTime = System.currentTimeMillis();
+        int index = input.readerIndex();
+        Object ret = codec.decode(channel, input);
+        int size = input.readerIndex() - index;
+        long elapsed = System.currentTimeMillis() - startTime;
+        if (ret instanceof Request) {
+            // server-side deserialize the Request
+            Object data = ((Request) ret).getData();
+            if (data instanceof RpcInvocation) {
+                RpcInvocation invocation = (RpcInvocation) data;
+                invocation.setAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_SIZE,
+                    String.valueOf(size));
+                invocation.setAttachment(AttachmentKeyConstants.SERVER_DESERIALIZE_TIME,
+                    String.valueOf(elapsed));
+            }
+        } else if (ret instanceof Response) {
+            // client-side deserialize the Response
+            Object result = ((Response) ret).getResult();
+            if (result instanceof AppResponse) {
+                AppResponse rpcResult = (AppResponse) result;
+                rpcResult.setAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_SIZE,
+                    String.valueOf(size));
+                rpcResult.setAttachment(AttachmentKeyConstants.CLIENT_DESERIALIZE_TIME,
+                    String.valueOf(elapsed));
+            }
+        }
+        return ret;
+    }
+}

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.remoting.Codec2
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.remoting.Codec2
@@ -1,0 +1,1 @@
+tracerCodec=com.alipay.sofa.tracer.plugins.dubbo26x.wrapper.DataSizeCodecWrapper

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.rpc.Filter
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.rpc.Filter
@@ -1,0 +1,1 @@
+dubboSofaTracerFilter=com.alipay.sofa.tracer.plugins.dubbo26x.DubboSofaTracerFilter

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/org.apache.dubbo.remoting.Codec2
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/org.apache.dubbo.remoting.Codec2
@@ -1,0 +1,1 @@
+tracerCodec=com.alipay.sofa.tracer.plugins.dubbo27x.wrapper.DataSizeCodecWrapper

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/org.apache.dubbo.rpc.Filter
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/src/main/resources/META-INF/dubbo/org.apache.dubbo.rpc.Filter
@@ -1,0 +1,1 @@
+dubboSofaTracerFilter=com.alipay.sofa.tracer.plugins.dubbo27x.DubboSofaTracerFilter

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -21,6 +21,7 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>3.12.1</version>
+            <optional>true</optional>
         </dependency>
         <!-- test dependency -->
         <dependency>

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -16,6 +16,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerFeignClient.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerFeignClient.java
@@ -107,7 +107,11 @@ public class SofaTracerFeignClient implements Client {
         if (sofaTracerSpan == null) {
             return;
         }
-        sofaTracerSpan.setTag(CommonSpanTags.RESP_SIZE, response.body().length());
+        Integer responseSize = null;
+        if (response.body() != null) {
+            responseSize = response.body().length();
+        }
+        sofaTracerSpan.setTag(CommonSpanTags.RESP_SIZE, responseSize);
         sofaTracerSpan.setTag(CommonSpanTags.CURRENT_THREAD_NAME, Thread.currentThread().getName());
         sofaTracerSpan.setTag(CommonSpanTags.RESULT_CODE, response.status());
     }

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>3.0.12.JST.1</version>
+    <version>3.0.12</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>3.0.11</version>
+    <version>3.0.12.JST</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>3.0.12.JST</version>
+    <version>3.0.12.JST.1</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -66,6 +66,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-tracer-okhttp-plugin</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot</artifactId>
         </dependency>
@@ -98,7 +103,7 @@
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-reporter</artifactId>
-            <version>2.7.13</version>
+            <version>2.7.15</version>
             <optional>true</optional>
         </dependency>
         <!-- test -->

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
-            <artifactId>sofa-tracer-dubbo-plugin</artifactId>
+            <artifactId>sofa-tracer-dubbo-common-plugin</artifactId>
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST</version>
+        <version>3.0.12.JST.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.12.JST.1</version>
+        <version>3.0.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.0.11</version>
+        <version>3.0.12.JST</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### Motivation:

1. Fix the problem: "When a server received dubbo requests and send another duubo reuqest to other server, its client span is lost."

### Modification:

1. Remove usage of ConcurrentHashMap in 2.6.X DubboSofaTracerFilter, bacause Invoker is reused, we cannot use it as a map key. And invokers between invoke and onResponse are different, which causing the lost of spans.
2. remove tracer-key from RpcContext when serverReceived
3. use traceId+spanId as key o remove usage of ConcurrentHashMap in 2.6.X DubboSofaTracerFilter in 2.7.X DubboSofaTracerFilter
4. put tracer string into RpcContext in 2.6.X and 2.7.X DubboSofaTracerFilter

### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
