### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: false
 
 jdk:
 - openjdk8


### PR DESCRIPTION
### Motivation:

[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

### Modification:

Remove deprecated sudo setting.

### Result:

