### PR TITLE
Invocation throws raw exception

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/Invocation.java
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/Invocation.java
@@ -49,11 +49,10 @@ public class Invocation {
         return args;
     }
 
-    public Object invoke() {
-        try {
-            return method.invoke(target, args);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public Object invoke() throws Exception {
+        // invoke外部已经处理过异常了, 没必要再包一层 RuntimeException
+        // 包一层会导致 内部抛出的 InvocationTargetException 被包装成 RuntimeException
+        // 导致 Spring 的 SQLExceptionTranslator 无法正确翻译异常信息
+        return method.invoke(target, args);
     }
 }


### PR DESCRIPTION
### Motivation:

bugfix: com.alipay.sofa.tracer.plugins.datasource.Invocation#invoke wraps raw exception as RuntimeException, causing Spring SQLExceptionTranslator fail to translate raw exception to right DataAccessException.

### Modification:

com.alipay.sofa.tracer.plugins.datasource.Invocation#invoke now throws raw exception.

### Result:
