### PR TITLE
Fixes gh-369

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/SmartDataSource.java
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/SmartDataSource.java
@@ -28,6 +28,7 @@ import java.util.List;
 /**
  * @author shusong.yss
  * @author qilong.zql
+ * @author chenchen
  * @since 2.2.0
  */
 public class SmartDataSource extends BaseDataSource {
@@ -118,9 +119,9 @@ public class SmartDataSource extends BaseDataSource {
 
             DataSource dataSource = getDelegate();
             String jdbcUrl = DataSourceUtils.getJdbcUrl(dataSource);
-            Endpoint endpoint = DataSourceUtils.getEndpointFromConnectionURL(jdbcUrl);
+            //tns or others
             traceAnnotations.add(new KeyValueAnnotation(DataSourceTracerKeys.DATABASE_ENDPOINT,
-                endpoint.getEndpoint()));
+                getEndpointsStr(DataSourceUtils.getEndpointsFromConnectionURL(jdbcUrl))));
 
             Prop prop = getProp();
             List<Interceptor> interceptors = getInterceptors();
@@ -151,4 +152,26 @@ public class SmartDataSource extends BaseDataSource {
                 .<Interceptor> singletonList(connectionTraceInterceptor));
         }
     }
+
+    private String getEndpointsStr(List<Endpoint> endpoints) {
+        if (null == endpoints) {
+            return StringUtils.EMPTY_STRING;
+        }
+
+        int endpointSize = endpoints.size();
+        if (0 == endpointSize) {
+            return StringUtils.EMPTY_STRING;
+        }
+
+        if (1 == endpointSize) {
+            return endpoints.get(0).getEndpoint();
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Endpoint endpoint : endpoints) {
+            sb.append(endpoint.getEndpoint()).append("/");
+        }
+        return sb.substring(0, sb.lastIndexOf("/"));
+    }
+
 }

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/test/java/com/sofa/tracer/plugins/datasource/OracleTnsTest.java
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/test/java/com/sofa/tracer/plugins/datasource/OracleTnsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sofa.tracer.plugins.datasource;
+
+import com.alipay.sofa.tracer.plugins.datasource.tracer.Endpoint;
+import com.alipay.sofa.tracer.plugins.datasource.utils.DataSourceUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ *
+ * @author chenchen6    2020/8/22 13:28
+ * @since
+ */
+public class OracleTnsTest {
+
+    private String jdbcUrl1  = "jdbc:oracle:thin:@(DESCRIPTION=(FAILOVER=on)(ADDRESS=(PROTOCOL=tcp)(HOST=tns1-svr)(PORT=1521))(ADDRESS=(PROTOCOL=tcp)(HOST=tns2-svr)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=tnsServiceName)))";
+    private String jdbcUrl3  = "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=tns3-svr)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=tns3ServiceName))";
+    private String jdbcUrl12 = "jdbc@:oracle:thin:";
+
+    @Test
+    public void testTnsDbType() {
+        Assert.assertTrue("oracle".equals(DataSourceUtils.resolveDbTypeFromUrl(jdbcUrl1)));
+        Assert.assertTrue("oracle".equals(DataSourceUtils.resolveDbTypeFromUrl(jdbcUrl3)));
+
+        boolean flagError = false;
+        try {
+            DataSourceUtils.resolveDbTypeFromUrl(jdbcUrl12);
+        } catch (Throwable throwable) {
+            flagError = true;
+        }
+        Assert.assertTrue(flagError);
+    }
+
+    @Test
+    public void testDataBase() {
+        Assert
+            .assertTrue("tnsServiceName".equals(DataSourceUtils.resolveDatabaseFromUrl(jdbcUrl1)));
+        Assert
+            .assertTrue("tns3ServiceName".equals(DataSourceUtils.resolveDatabaseFromUrl(jdbcUrl3)));
+    }
+
+    @Test
+    public void testEndpoints() {
+        List<Endpoint> endpoints;
+        endpoints = DataSourceUtils.getEndpointsFromConnectionURL(jdbcUrl1);
+        Assert.assertEquals(2, endpoints.size());
+        Assert.assertEquals("tns1-svr:1521", endpoints.get(0).getEndpoint());
+        Assert.assertEquals("tns2-svr:1521", endpoints.get(1).getEndpoint());
+
+        endpoints = DataSourceUtils.getEndpointsFromConnectionURL(jdbcUrl3);
+        Assert.assertEquals(1, endpoints.size());
+        Assert.assertEquals("tns3-svr:1521", endpoints.get(0).getEndpoint());
+    }
+}


### PR DESCRIPTION
### Motivation:

SOFA-Tracer datasource-plugin support parse oracle tns .

### Modification:

Oracle TNS can be parsed.

### Result:

Fixes #<369>. 

Fixes gh-369.