### PR TITLE
Fixes gh-396

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/src/main/java/com/sofa/alipay/tracer/plugins/kafkamq/factories/SofaTracerKafkaConsumerFactory.java
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/src/main/java/com/sofa/alipay/tracer/plugins/kafkamq/factories/SofaTracerKafkaConsumerFactory.java
@@ -57,7 +57,7 @@ public class SofaTracerKafkaConsumerFactory<K, V> implements ConsumerFactory<K, 
     public Consumer<K, V> createConsumer(String groupId, String clientIdPrefix,
                                          String clientIdSuffix) {
         return new SofaTracerKafkaConsumer<>(consumerFactory.createConsumer(groupId,
-            clientIdSuffix, clientIdSuffix));
+            clientIdPrefix, clientIdSuffix));
     }
 
     @Override


### PR DESCRIPTION
### Motivation:

SOFA-Tracer kafkamq-plugin the context of kafka send ends safely.

### Modification:

the context of kafka send ends safely.

### Result:

Fixes gh-396.
