### PR TITLE
Restore parent span for redis plugin

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/common/RedisActionWrapperHelper.java
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/common/RedisActionWrapperHelper.java
@@ -18,6 +18,7 @@ package com.sofa.alipay.tracer.plugins.spring.redis.common;
 
 import com.alipay.common.tracer.core.SofaTracer;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
+import com.alipay.common.tracer.core.constants.SofaTracerConstant;
 import com.alipay.common.tracer.core.holder.SofaTraceContextHolder;
 import com.alipay.common.tracer.core.span.CommonSpanTags;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
@@ -88,35 +89,56 @@ public class RedisActionWrapperHelper {
 
     public <T> T decorate(Supplier<T> supplier, String operateName) {
         Span span = buildSpan(operateName);
+        Throwable candidateThrowable = null;
         try {
             return supplier.get();
         } catch (Throwable t) {
+            candidateThrowable = t;
             throw t;
         } finally {
-            span.finish();
+            if (candidateThrowable != null) {
+                span.setTag(Tags.ERROR.getKey(),candidateThrowable.getMessage());
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_ERROR);
+            } else {
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_SUCCESS);
+            }
         }
     }
 
     public void decorate(Action action, String operateName) {
         Span span = buildSpan(operateName);
+        Throwable candidateThrowable = null;
         try {
             action.execute();
         } catch (Throwable t) {
+            candidateThrowable = t;
             throw t;
         } finally {
-            span.finish();
+            if (candidateThrowable != null) {
+                span.setTag(Tags.ERROR.getKey(),candidateThrowable.getMessage());
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_ERROR);
+            } else {
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_SUCCESS);
+            }
         }
     }
 
     public <T extends Exception> void decorateThrowing(ThrowingAction<T> action, String operateName)
                                                                                                     throws T {
         Span span = buildSpan(operateName);
+        Throwable candidateThrowable = null;
         try {
             action.execute();
         } catch (Throwable t) {
+            candidateThrowable = t;
             throw t;
         } finally {
-            span.finish();
+            if (candidateThrowable != null) {
+                span.setTag(Tags.ERROR.getKey(),candidateThrowable.getMessage());
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_ERROR);
+            } else {
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_SUCCESS);
+            }
         }
     }
 
@@ -124,12 +146,19 @@ public class RedisActionWrapperHelper {
                                                        String operateName) throws T {
 
         Span span = buildSpan(operateName);
+        Throwable candidateThrowable = null;
         try {
             return supplier.get();
         } catch (Throwable t) {
+            candidateThrowable = t;
             throw t;
         } finally {
-            span.finish();
+            if (candidateThrowable != null) {
+                span.setTag(Tags.ERROR.getKey(),candidateThrowable.getMessage());
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_ERROR);
+            } else {
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_SUCCESS);
+            }
         }
     }
 
@@ -142,11 +171,11 @@ public class RedisActionWrapperHelper {
             throw t;
         } finally {
             if (candidateThrowable != null) {
-
+                span.setTag(Tags.ERROR.getKey(),candidateThrowable.getMessage());
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_ERROR);
             } else {
-
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_SUCCESS);
             }
-            redisSofaTracer.clientReceiveTagFinish((SofaTracerSpan) span, "00");
         }
     }
 
@@ -160,11 +189,11 @@ public class RedisActionWrapperHelper {
             throw t;
         } finally {
             if (candidateThrowable != null) {
-
+                span.setTag(Tags.ERROR.getKey(),candidateThrowable.getMessage());
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_ERROR);
             } else {
-
+                redisSofaTracer.clientReceive(SofaTracerConstant.RESULT_CODE_SUCCESS);
             }
-            redisSofaTracer.clientReceive("");
         }
     }
 


### PR DESCRIPTION
### Motivation:

解决redis plugin未恢复paren span,导致span id的层级无限增长的问题

### Modification:

Describe the idea and modifications you've done.

在finish span后，将parent span恢复到当前栈中

### Result:

Fixes #463. 

