### PR TITLE
Upgrade to use a higher version of feign

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofaboot-dependencies</artifactId>
-        <version>3.1.1</version>
+        <version>3.12.1</version>
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
@@ -210,14 +210,21 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-openfeign</artifactId>
-                <version>2.1.0.RELEASE</version>
+                <version>3.0.5</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+                <version>3.0.5</version>
                 <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream</artifactId>
-                <version>2.1.0.RELEASE</version>
+                <version>3.0.5.RELEASE</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -19,6 +19,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.19.0-GA</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>tracer-core</artifactId>
         </dependency>

--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/src/main/java/com/sofa/alipay/tracer/plugins/kafkamq/consumer/SofaTracerKafkaConsumer.java
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/src/main/java/com/sofa/alipay/tracer/plugins/kafkamq/consumer/SofaTracerKafkaConsumer.java
@@ -25,6 +25,7 @@ import com.alipay.common.tracer.core.span.SofaTracerSpan;
 import com.sofa.alipay.tracer.plugins.kafkamq.carrier.KafkaMqExtractCarrier;
 import com.sofa.alipay.tracer.plugins.kafkamq.tracers.KafkaMQConsumeTracer;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -177,6 +178,11 @@ public class SofaTracerKafkaConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
+    public void seek(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
+        consumer.seek(topicPartition, offsetAndMetadata);
+    }
+
+    @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
         consumer.seekToBeginning(partitions);
     }
@@ -204,6 +210,17 @@ public class SofaTracerKafkaConsumer<K, V> implements Consumer<K, V> {
     @Override
     public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
         return consumer.committed(partition, timeout);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> set) {
+        return consumer.committed(set);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> set,
+                                                            Duration duration) {
+        return consumer.committed(set, duration);
     }
 
     @Override
@@ -277,6 +294,16 @@ public class SofaTracerKafkaConsumer<K, V> implements Consumer<K, V> {
     public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions,
                                                 Duration timeout) {
         return consumer.endOffsets(partitions, timeout);
+    }
+
+    @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        return consumer.groupMetadata();
+    }
+
+    @Override
+    public void enforceRebalance() {
+        consumer.enforceRebalance();
     }
 
     @Override

--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/src/main/java/com/sofa/alipay/tracer/plugins/kafkamq/producer/SofaTracerKafkaProducer.java
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/src/main/java/com/sofa/alipay/tracer/plugins/kafkamq/producer/SofaTracerKafkaProducer.java
@@ -27,6 +27,7 @@ import com.alipay.common.tracer.core.span.SofaTracerSpan;
 import com.alipay.common.tracer.core.tracer.AbstractTracer;
 import com.sofa.alipay.tracer.plugins.kafkamq.carrier.KafkaMqInjectCarrier;
 import com.sofa.alipay.tracer.plugins.kafkamq.tracers.KafkaMQSendTracer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -39,6 +40,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.header.Headers;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -85,6 +87,13 @@ public class SofaTracerKafkaProducer<K, V> implements Producer<K, V> {
     public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                          String consumerGroupId) throws ProducerFencedException {
         producer.sendOffsetsToTransaction(offsets, consumerGroupId);
+    }
+
+    @Override
+    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> map,
+                                         ConsumerGroupMetadata consumerGroupMetadata)
+                                                                                     throws ProducerFencedException {
+        producer.sendOffsetsToTransaction(map, consumerGroupMetadata);
     }
 
     @Override
@@ -140,6 +149,11 @@ public class SofaTracerKafkaProducer<K, V> implements Producer<K, V> {
     @Override
     public void close(long timeout, TimeUnit timeUnit) {
         producer.close(timeout, timeUnit);
+    }
+
+    @Override
+    public void close(Duration duration) {
+        producer.close(duration);
     }
 
     private void appendSpanTagsAndInject(ProducerRecord<K, V> producerRecord,

--- a/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>
+            <version>3.8.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/src/test/java/com/sofa/tracer/plugins/rabbitmq/base/MockRabbitMqExtractCarrier.java
+++ b/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/src/test/java/com/sofa/tracer/plugins/rabbitmq/base/MockRabbitMqExtractCarrier.java
@@ -39,16 +39,16 @@ public class MockRabbitMqExtractCarrier {
         Map<String, String> map = Collections.singletonMap(key, value);
         Map<String, Object> headers = Collections.singletonMap(key, value);
         RabbitMqExtractCarrier carrier = new RabbitMqExtractCarrier(headers);
-        final Iterator<Map.Entry<String, String>> iterator = carrier.iterator();
-        assertThat(iterator).containsAll(map.entrySet());
+        //final Iterator<Map.Entry<String, String>> iterator = carrier.iterator();
+        assertThat(carrier).containsAll(map.entrySet());
     }
 
     @Test
     public void testIterator_whenNullValue() {
         Map<String, Object> headers = Collections.singletonMap("testSOFATracerId", null);
         RabbitMqExtractCarrier carrier = new RabbitMqExtractCarrier(headers);
-        final Iterator<Map.Entry<String, String>> iterator = carrier.iterator();
-        assertThat(iterator).doesNotContainNull();
+        //final Iterator<Map.Entry<String, String>> iterator = carrier.iterator();
+        assertThat(carrier).doesNotContainNull();
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/common/RedisCommand.java
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/common/RedisCommand.java
@@ -256,6 +256,18 @@ public final class RedisCommand {
     public static final String IDLETIME                      = "IDLETIME";
     public static final String REFCOUNT                      = "REFCOUNT";
     public static final String EXECUTE                       = "EXECUTE";
+    public static final String LPOS                          = "LPOS";
+    public static final String XACK                          = "XACK";
+    public static final String XCLAIMJUSTID                  = "XCLAIMJUSTID";
+    public static final String XCLAIM                        = "XCLAIM";
+    public static final String XDEL                          = "XDEL";
+    public static final String XGROUPCREATE                  = "XGROUPCREATE";
+    public static final String XGROUPDELCONSUMER             = "XGROUPDELCONSUMER";
+    public static final String XGROUPDESTROY                 = "XGROUPDESTROY";
+    public static final String XINFO                         = "XINFO";
+    public static final String XINFOGROUPS                   = "XINFOGROUPS";
+    public static final String XINFOCONSUMERS                = "XINFOCONSUMERS";
+    public static final String XTRIM                         = "XTRIM";
 
     private RedisCommand() {
     }

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingReactiveRedisClusterConnection.java
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingReactiveRedisClusterConnection.java
@@ -18,6 +18,7 @@ package com.sofa.alipay.tracer.plugins.spring.redis.connections;
 
 import com.sofa.alipay.tracer.plugins.spring.redis.common.RedisActionWrapperHelper;
 import com.sofa.alipay.tracer.plugins.spring.redis.common.RedisCommand;
+import org.springframework.data.redis.connection.ClusterInfo;
 import org.springframework.data.redis.connection.ReactiveClusterGeoCommands;
 import org.springframework.data.redis.connection.ReactiveClusterHashCommands;
 import org.springframework.data.redis.connection.ReactiveClusterHyperLogLogCommands;
@@ -26,13 +27,19 @@ import org.springframework.data.redis.connection.ReactiveClusterListCommands;
 import org.springframework.data.redis.connection.ReactiveClusterNumberCommands;
 import org.springframework.data.redis.connection.ReactiveClusterServerCommands;
 import org.springframework.data.redis.connection.ReactiveClusterSetCommands;
+import org.springframework.data.redis.connection.ReactiveClusterStreamCommands;
 import org.springframework.data.redis.connection.ReactiveClusterStringCommands;
 import org.springframework.data.redis.connection.ReactiveClusterZSetCommands;
 import org.springframework.data.redis.connection.ReactivePubSubCommands;
 import org.springframework.data.redis.connection.ReactiveRedisClusterConnection;
 import org.springframework.data.redis.connection.ReactiveScriptingCommands;
 import org.springframework.data.redis.connection.RedisClusterNode;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
 
 public class TracingReactiveRedisClusterConnection implements ReactiveRedisClusterConnection {
 
@@ -101,6 +108,11 @@ public class TracingReactiveRedisClusterConnection implements ReactiveRedisClust
     }
 
     @Override
+    public ReactiveClusterStreamCommands streamCommands() {
+        return reactiveRedisClusterConnection.streamCommands();
+    }
+
+    @Override
   public Mono<String> ping(RedisClusterNode node) {
     return actionWrapper.doInScope(RedisCommand.PING,
         () -> reactiveRedisClusterConnection.ping(node));
@@ -125,4 +137,90 @@ public class TracingReactiveRedisClusterConnection implements ReactiveRedisClust
   public Mono<String> ping() {
     return actionWrapper.doInScope(RedisCommand.PING, () -> reactiveRedisClusterConnection.ping());
   }
+
+    @Override
+    public Flux<RedisClusterNode> clusterGetNodes() {
+        return reactiveRedisClusterConnection.clusterGetNodes();
+    }
+
+    @Override
+    public Flux<RedisClusterNode> clusterGetSlaves(RedisClusterNode master) {
+        return reactiveRedisClusterConnection.clusterGetSlaves(master);
+    }
+
+    @Override
+    public Mono<Map<RedisClusterNode, Collection<RedisClusterNode>>> clusterGetMasterSlaveMap() {
+        return reactiveRedisClusterConnection.clusterGetMasterSlaveMap();
+    }
+
+    @Override
+    public Mono<Integer> clusterGetSlotForKey(ByteBuffer key) {
+        return reactiveRedisClusterConnection.clusterGetSlotForKey(key);
+    }
+
+    @Override
+    public Mono<RedisClusterNode> clusterGetNodeForSlot(int slot) {
+        return reactiveRedisClusterConnection.clusterGetNodeForSlot(slot);
+    }
+
+    @Override
+    public Mono<RedisClusterNode> clusterGetNodeForKey(ByteBuffer key) {
+        return reactiveRedisClusterConnection.clusterGetNodeForKey(key);
+    }
+
+    @Override
+    public Mono<ClusterInfo> clusterGetClusterInfo() {
+        return reactiveRedisClusterConnection.clusterGetClusterInfo();
+    }
+
+    @Override
+    public Mono<Void> clusterAddSlots(RedisClusterNode node, int... slots) {
+        return reactiveRedisClusterConnection.clusterAddSlots(node, slots);
+    }
+
+    @Override
+    public Mono<Void> clusterAddSlots(RedisClusterNode node, RedisClusterNode.SlotRange range) {
+        return reactiveRedisClusterConnection.clusterAddSlots(node, range);
+    }
+
+    @Override
+    public Mono<Long> clusterCountKeysInSlot(int slot) {
+        return reactiveRedisClusterConnection.clusterCountKeysInSlot(slot);
+    }
+
+    @Override
+    public Mono<Void> clusterDeleteSlots(RedisClusterNode node, int... slots) {
+        return reactiveRedisClusterConnection.clusterDeleteSlots(node, slots);
+    }
+
+    @Override
+    public Mono<Void> clusterDeleteSlotsInRange(RedisClusterNode node,
+                                                RedisClusterNode.SlotRange range) {
+        return reactiveRedisClusterConnection.clusterDeleteSlotsInRange(node, range);
+    }
+
+    @Override
+    public Mono<Void> clusterForget(RedisClusterNode node) {
+        return reactiveRedisClusterConnection.clusterForget(node);
+    }
+
+    @Override
+    public Mono<Void> clusterMeet(RedisClusterNode node) {
+        return reactiveRedisClusterConnection.clusterMeet(node);
+    }
+
+    @Override
+    public Mono<Void> clusterSetSlot(RedisClusterNode node, int slot, AddSlots mode) {
+        return reactiveRedisClusterConnection.clusterSetSlot(node, slot, mode);
+    }
+
+    @Override
+    public Flux<ByteBuffer> clusterGetKeysInSlot(int slot, int count) {
+        return reactiveRedisClusterConnection.clusterGetKeysInSlot(slot, count);
+    }
+
+    @Override
+    public Mono<Void> clusterReplicate(RedisClusterNode master, RedisClusterNode replica) {
+        return reactiveRedisClusterConnection.clusterReplicate(master, replica);
+    }
 }

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingReactiveRedisConnection.java
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingReactiveRedisConnection.java
@@ -29,6 +29,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnection;
 import org.springframework.data.redis.connection.ReactiveScriptingCommands;
 import org.springframework.data.redis.connection.ReactiveServerCommands;
 import org.springframework.data.redis.connection.ReactiveSetCommands;
+import org.springframework.data.redis.connection.ReactiveStreamCommands;
 import org.springframework.data.redis.connection.ReactiveStringCommands;
 import org.springframework.data.redis.connection.ReactiveZSetCommands;
 import reactor.core.publisher.Mono;
@@ -111,6 +112,11 @@ public class TracingReactiveRedisConnection implements ReactiveRedisConnection {
     @Override
     public ReactiveServerCommands serverCommands() {
         return reactiveRedisConnection.serverCommands();
+    }
+
+    @Override
+    public ReactiveStreamCommands streamCommands() {
+        return reactiveRedisConnection.streamCommands();
     }
 
     @Override

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingRedisConnection.java
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingRedisConnection.java
@@ -45,6 +45,16 @@ import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.connection.SortParameters;
 import org.springframework.data.redis.connection.Subscription;
 import org.springframework.data.redis.connection.ValueEncoding;
+import org.springframework.data.redis.connection.stream.ByteRecord;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamInfo;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.types.Expiration;
@@ -466,6 +476,11 @@ public class TracingRedisConnection implements RedisConnection {
   }
 
     @Override
+    public List<Long> lPos(byte[] key, byte[] element, Integer rank, Integer count) {
+        return actionWrapper.doInScope(RedisCommand.LPOS, key, () -> connection.lPos(key, element, rank, count));
+    }
+
+    @Override
   public Long lPush(byte[] key, byte[]... values) {
     return actionWrapper.doInScope(RedisCommand.LPUSH, key, () -> connection.lPush(key, values));
   }
@@ -813,6 +828,11 @@ public class TracingRedisConnection implements RedisConnection {
   }
 
     @Override
+    public Long zLexCount(byte[] key, Range range) {
+        return actionWrapper.doInScope(RedisCommand.ZLEXCOUNT, key, () -> connection.zLexCount(key, range));
+    }
+
+    @Override
   public Long zCard(byte[] key) {
     return actionWrapper.doInScope(RedisCommand.ZCARD, key, () -> connection.zCard(key));
   }
@@ -896,6 +916,12 @@ public class TracingRedisConnection implements RedisConnection {
     return actionWrapper
         .doInScope(RedisCommand.ZRANGEBYLEX, key, () -> connection.zRangeByLex(key, range, limit));
   }
+
+    @Override
+    public Set<byte[]> zRevRangeByLex(byte[] key, Range range, Limit limit) {
+        return actionWrapper
+                .doInScope(RedisCommand.ZREVRANGEBYLEX, key, () -> connection.zRevRangeByLex(key, range, limit));
+    }
 
     @Override
   public Boolean hSet(byte[] key, byte[] field, byte[] value) {
@@ -1286,4 +1312,120 @@ public class TracingRedisConnection implements RedisConnection {
     actionWrapper.doInScope(RedisCommand.PFMERGE,
         () -> connection.pfMerge(destinationKey, sourceKeys));
   }
+
+    @Override
+    public Long xAck(byte[] key, String group, RecordId... recordIds) {
+        return actionWrapper.doInScope(RedisCommand.XACK, key, () -> connection.xAck(key, group, recordIds));
+    }
+
+    @Override
+    public RecordId xAdd(MapRecord<byte[], byte[], byte[]> record, XAddOptions options) {
+        return actionWrapper.doInScope(RedisCommand.XADD, () -> connection.xAdd(record, options));
+    }
+
+    @Override
+    public List<RecordId> xClaimJustId(byte[] key, String group, String newOwner, XClaimOptions options) {
+        return actionWrapper.doInScope(RedisCommand.XCLAIMJUSTID, key,
+                () -> connection.xClaimJustId(key, group, newOwner, options));
+    }
+
+    @Override
+    public List<ByteRecord> xClaim(byte[] key, String group, String newOwner, XClaimOptions options) {
+        return actionWrapper.doInScope(RedisCommand.XCLAIM, key,
+                () -> connection.xClaim(key, group, newOwner, options));
+    }
+
+    @Override
+    public Long xDel(byte[] key, RecordId... recordIds) {
+        return actionWrapper.doInScope(RedisCommand.XDEL, key, () -> connection.xDel(key, recordIds));
+    }
+
+    @Override
+    public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset) {
+        return actionWrapper.doInScope(RedisCommand.XGROUPCREATE, key,
+                () -> connection.xGroupCreate(key, groupName, readOffset));
+    }
+
+    @Override
+    public String xGroupCreate(byte[] key, String groupName, ReadOffset readOffset, boolean mkStream) {
+        return actionWrapper.doInScope(RedisCommand.XGROUPCREATE, key,
+                () -> connection.xGroupCreate(key, groupName, readOffset, mkStream));
+    }
+
+    @Override
+    public Boolean xGroupDelConsumer(byte[] key, Consumer consumer) {
+        return actionWrapper.doInScope(RedisCommand.XGROUPDELCONSUMER, key,
+                () -> connection.xGroupDelConsumer(key, consumer));
+    }
+
+    @Override
+    public Boolean xGroupDestroy(byte[] key, String groupName) {
+        return actionWrapper.doInScope(RedisCommand.XGROUPDESTROY, key,
+                () -> connection.xGroupDestroy(key, groupName));
+    }
+
+    @Override
+    public StreamInfo.XInfoStream xInfo(byte[] key) {
+        return actionWrapper.doInScope(RedisCommand.XINFO, key,
+                () -> connection.xInfo(key));
+    }
+
+    @Override
+    public StreamInfo.XInfoGroups xInfoGroups(byte[] key) {
+        return actionWrapper.doInScope(RedisCommand.XINFOGROUPS, key,
+                () -> connection.xInfoGroups(key));
+    }
+
+    @Override
+    public StreamInfo.XInfoConsumers xInfoConsumers(byte[] key, String groupName) {
+        return actionWrapper.doInScope(RedisCommand.XINFOCONSUMERS, key,
+                () -> connection.xInfoConsumers(key, groupName));
+    }
+
+    @Override
+    public Long xLen(byte[] key) {
+        return actionWrapper.doInScope(RedisCommand.XLEN, key, () -> connection.xLen(key));
+    }
+
+    @Override
+    public PendingMessagesSummary xPending(byte[] key, String groupName) {
+        return actionWrapper.doInScope(RedisCommand.XPENDING, key, () -> connection.xPending(key, groupName));
+    }
+
+    @Override
+    public PendingMessages xPending(byte[] key, String groupName, XPendingOptions options) {
+        return actionWrapper.doInScope(RedisCommand.XPENDING, key,
+                () -> connection.xPending(key, groupName, options));
+    }
+
+    @Override
+    public List<ByteRecord> xRange(byte[] key, org.springframework.data.domain.Range<String> range, Limit limit) {
+        return actionWrapper.doInScope(RedisCommand.XRANGE, key,
+                () -> connection.xRange(key, range, limit));
+    }
+
+    @Override
+    public List<ByteRecord> xRead(StreamReadOptions readOptions, StreamOffset<byte[]>... streams) {
+        return actionWrapper.doInScope(RedisCommand.XREAD, () -> connection.xRead(readOptions, streams));
+    }
+
+    @Override
+    public List<ByteRecord> xReadGroup(Consumer consumer, StreamReadOptions readOptions, StreamOffset<byte[]>... streams) {
+        return actionWrapper.doInScope(RedisCommand.XREADGROUP, () -> connection.xReadGroup(consumer, readOptions, streams));
+    }
+
+    @Override
+    public List<ByteRecord> xRevRange(byte[] key, org.springframework.data.domain.Range<String> range, Limit limit) {
+        return actionWrapper.doInScope(RedisCommand.XREVRANGE, key, () -> connection.xRevRange(key, range, limit));
+    }
+
+    @Override
+    public Long xTrim(byte[] key, long count) {
+        return actionWrapper.doInScope(RedisCommand.XTRIM, key, () -> connection.xTrim(key, count));
+    }
+
+    @Override
+    public Long xTrim(byte[] key, long count, boolean approximateTrimming) {
+        return actionWrapper.doInScope(RedisCommand.XTRIM, key, () -> connection.xTrim(key, count, approximateTrimming));
+    }
 }

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -19,6 +19,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>tracer-core</artifactId>
         </dependency>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/carriers/FeignRequestHeadersCarrier.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/carriers/FeignRequestHeadersCarrier.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.tracer.plugins.springcloud.carriers;
 
-import feign.Request;
 import io.opentracing.propagation.TextMap;
 
 import java.util.ArrayList;
@@ -28,15 +27,15 @@ import java.util.Map;
  * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/3/13 5:09 PM
  * @since:
  **/
-public class FeignRequestCarrier implements TextMap {
+public class FeignRequestHeadersCarrier implements TextMap {
 
-    private Request request;
+    private Map<String, Collection<String>> headers;
 
-    public FeignRequestCarrier(Request request) {
-        if (request == null) {
+    public FeignRequestHeadersCarrier(Map<String, Collection<String>> headers) {
+        if (headers == null) {
             throw new NullPointerException("Headers request should not be null!");
         }
-        this.request = request;
+        this.headers = headers;
     }
 
     @Override
@@ -46,11 +45,11 @@ public class FeignRequestCarrier implements TextMap {
 
     @Override
     public void put(String key, String val) {
-        Collection<String> vals = request.headers().get(key);
+        Collection<String> vals = headers.get(key);
         if (vals == null) {
             vals = new ArrayList<>();
         }
         vals.add(val);
-        request.headers().put(key, vals);
+        headers.put(key, vals);
     }
 }

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerFeignClient.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerFeignClient.java
@@ -23,7 +23,7 @@ import com.alipay.common.tracer.core.registry.ExtendFormat;
 import com.alipay.common.tracer.core.span.CommonSpanTags;
 import com.alipay.common.tracer.core.span.SofaTracerSpan;
 import com.alipay.common.tracer.core.utils.StringUtils;
-import com.alipay.sofa.tracer.plugins.springcloud.carriers.FeignRequestCarrier;
+import com.alipay.sofa.tracer.plugins.springcloud.carriers.FeignRequestHeadersCarrier;
 import com.alipay.sofa.tracer.plugins.springcloud.tracers.FeignClientTracer;
 import feign.Client;
 import feign.Request;
@@ -32,7 +32,9 @@ import io.opentracing.tag.Tags;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/3/13 10:50 AM
@@ -56,17 +58,17 @@ public class SofaTracerFeignClient implements Client {
         SofaTracerSpan sofaTracerSpan = null;
         int resultCode = -1;
         try {
-            sofaTracerSpan = feignClientTracer.clientSend(request.method());
+            sofaTracerSpan = feignClientTracer.clientSend(request.httpMethod().name());
             // set tags
-            try {
-                appendRequestSpanTagsAndInject(request, sofaTracerSpan);
-            } catch (UnsupportedOperationException e) {
-                // if header is Unmodifiable，renew request
-                request = Request.create(request.httpMethod(), request.url(), new LinkedHashMap<>(
-                    request.headers()), request.requestBody());
-                // ignore appendRequestSpanTags,appendRequestSpanTagsAndInject has do it
-                injectCarrier(request, sofaTracerSpan);
-            }
+            appendRequestSpanTags(request, sofaTracerSpan);
+            // new a headers
+            LinkedHashMap<String, Collection<String>> headers = new LinkedHashMap<>(
+                request.headers());
+            // inject carrier into headers
+            injectCarrier(headers, sofaTracerSpan);
+            // renew request with the headers that have been injected into the carrier
+            request = Request.create(request.httpMethod(), request.url(), headers, request.body(),
+                request.charset(), request.requestTemplate());
             Response response = delegate.execute(request, options);
             // set result tags
             appendResponseSpanTags(response, sofaTracerSpan);
@@ -126,18 +128,6 @@ public class SofaTracerFeignClient implements Client {
         sofaTracerSpan.setTag(CommonSpanTags.RESULT_CODE, response.status());
     }
 
-    /**
-     * append request tags for current span
-     * @param request
-     * @param sofaTracerSpan
-     */
-    private void appendRequestSpanTagsAndInject(Request request, SofaTracerSpan sofaTracerSpan) {
-
-        appendRequestSpanTags(request, sofaTracerSpan);
-        //carrier
-        this.injectCarrier(request, sofaTracerSpan);
-    }
-
     private void appendRequestSpanTags(Request request, SofaTracerSpan sofaTracerSpan) {
         if (sofaTracerSpan == null) {
             return;
@@ -146,7 +136,7 @@ public class SofaTracerFeignClient implements Client {
         String appName = SofaTracerConfiguration.getProperty(
             SofaTracerConfiguration.TRACER_APPNAME_KEY, StringUtils.EMPTY_STRING);
         //methodName
-        String methodName = request.method();
+        String methodName = request.httpMethod().name();
         //appName
         sofaTracerSpan.setTag(CommonSpanTags.LOCAL_APP, appName == null ? StringUtils.EMPTY_STRING
             : appName);
@@ -165,11 +155,9 @@ public class SofaTracerFeignClient implements Client {
         }
     }
 
-    private void injectCarrier(Object request, SofaTracerSpan currentSpan) {
-        if (request instanceof Request) {
-            SofaTracer sofaTracer = this.feignClientTracer.getSofaTracer();
-            sofaTracer.inject(currentSpan.getSofaTracerSpanContext(),
-                ExtendFormat.Builtin.B3_HTTP_HEADERS, new FeignRequestCarrier((Request) request));
-        }
+    private void injectCarrier(Map<String, Collection<String>> headers, SofaTracerSpan currentSpan) {
+        SofaTracer sofaTracer = this.feignClientTracer.getSofaTracer();
+        sofaTracer.inject(currentSpan.getSofaTracerSpanContext(),
+            ExtendFormat.Builtin.B3_HTTP_HEADERS, new FeignRequestHeadersCarrier(headers));
     }
 }

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerFeignContext.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerFeignContext.java
@@ -18,10 +18,11 @@ package com.alipay.sofa.tracer.plugins.springcloud.instruments.feign;
 
 import feign.Client;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerProperties;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 import org.springframework.cloud.openfeign.FeignContext;
-import org.springframework.cloud.openfeign.ribbon.CachingSpringLoadBalancerFactory;
-import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
+import org.springframework.cloud.openfeign.loadbalancer.FeignBlockingLoadBalancerClient;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -65,12 +66,13 @@ public class SofaTracerFeignContext extends FeignContext {
         }
         if (bean instanceof Client) {
             // LoadBalancerFeignClient Type Wrapper to SofaTracerLoadBalancedFeignClient
-            if (bean instanceof LoadBalancerFeignClient
+            if (bean instanceof FeignBlockingLoadBalancerClient
                 && !(bean instanceof SofaTracerLoadBalancedFeignClient)) {
                 return new SofaTracerLoadBalancedFeignClient(
-                    newSofaTracerFeignClient(((LoadBalancerFeignClient) bean).getDelegate()),
-                    beanFactory.getBean(CachingSpringLoadBalancerFactory.class),
-                    beanFactory.getBean(SpringClientFactory.class));
+                    newSofaTracerFeignClient(((FeignBlockingLoadBalancerClient) bean).getDelegate()),
+                    beanFactory.getBean(LoadBalancerClient.class), beanFactory
+                        .getBean(LoadBalancerProperties.class), beanFactory
+                        .getBean(LoadBalancerClientFactory.class));
             }
             return newSofaTracerFeignClient((Client) bean);
         }

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerLoadBalancedFeignClient.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/instruments/feign/SofaTracerLoadBalancedFeignClient.java
@@ -17,19 +17,20 @@
 package com.alipay.sofa.tracer.plugins.springcloud.instruments.feign;
 
 import feign.Client;
-import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
-import org.springframework.cloud.openfeign.ribbon.CachingSpringLoadBalancerFactory;
-import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerProperties;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
+import org.springframework.cloud.openfeign.loadbalancer.FeignBlockingLoadBalancerClient;
 
 /**
  * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/3/13 5:53 PM
  * @since:
  **/
-public class SofaTracerLoadBalancedFeignClient extends LoadBalancerFeignClient {
+public class SofaTracerLoadBalancedFeignClient extends FeignBlockingLoadBalancerClient {
 
-    public SofaTracerLoadBalancedFeignClient(Client client,
-                                             CachingSpringLoadBalancerFactory cachingSpringLoadBalancerFactory,
-                                             SpringClientFactory clientFactory) {
-        super(client, cachingSpringLoadBalancerFactory, clientFactory);
+    public SofaTracerLoadBalancedFeignClient(Client client, LoadBalancerClient loadBalancerClient,
+                                             LoadBalancerProperties properties,
+                                             LoadBalancerClientFactory loadBalancerClientFactory) {
+        super(client, loadBalancerClient, properties, loadBalancerClientFactory);
     }
 }

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/registry/AbstractTextB3Formatter.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/registry/AbstractTextB3Formatter.java
@@ -146,7 +146,6 @@ public abstract class AbstractTextB3Formatter implements RegistryExtractorInject
         carrier.put(TRACE_ID_KEY_HEAD, encodedValue(spanContext.getTraceId()));
         carrier.put(SPAN_ID_KEY_HEAD, encodedValue(spanContext.getSpanId()));
         carrier.put(PARENT_SPAN_ID_KEY_HEAD, encodedValue(spanContext.getParentId()));
-        carrier.put(SPAN_ID_KEY_HEAD, encodedValue(spanContext.getSpanId()));
         carrier.put(SAMPLED_KEY_HEAD, encodedValue(String.valueOf(spanContext.isSampled())));
         //System Baggage items
         for (Map.Entry<String, String> entry : spanContext.getSysBaggage().entrySet()) {

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -101,7 +101,8 @@
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
-            <artifactId>infra-sofa-boot-starter</artifactId>
+            <artifactId>sofa-boot</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -148,6 +149,13 @@
 
         <dependency>
             <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.1.2</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>
             <version>3.8.2</version>
             <optional>true</optional>
@@ -156,7 +164,6 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <version>2.1.8.RELEASE</version>
             <optional>true</optional>
         </dependency>
 
@@ -190,6 +197,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestBase.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestBase.java
@@ -21,7 +21,7 @@ import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.reporter.digest.manager.SofaTracerDigestReporterAsyncManager;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterCycleTimesManager;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterManager;
-import com.alipay.sofa.infra.listener.SofaBootstrapRunListener;
+import com.alipay.sofa.boot.listener.SofaBootstrapRunListener;
 import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcTracer;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestCloudBase.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestCloudBase.java
@@ -18,7 +18,7 @@ package com.alipay.sofa.tracer.boot.base;
 
 import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
-import com.alipay.sofa.infra.listener.SofaBootstrapRunListener;
+import com.alipay.sofa.boot.listener.SofaBootstrapRunListener;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/ConfigurationHolderListener.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/ConfigurationHolderListener.java
@@ -18,7 +18,7 @@ package com.alipay.sofa.tracer.boot.base;
 
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.utils.StringUtils;
-import com.alipay.sofa.infra.utils.SOFABootEnvUtils;
+import com.alipay.sofa.boot.util.SofaBootEnvUtils;
 import com.alipay.sofa.tracer.boot.properties.SofaTracerProperties;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
@@ -33,7 +33,7 @@ public class ConfigurationHolderListener implements
     @Override
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         ConfigurableEnvironment environment = event.getEnvironment();
-        if (SOFABootEnvUtils.isSpringCloudBootstrapEnvironment(environment)) {
+        if (SofaBootEnvUtils.isSpringCloudBootstrapEnvironment(environment)) {
             return;
         }
         SofaTracerProperties sofaTracerProperties = new SofaTracerProperties();

--- a/tracer-sofa-boot-starter/src/test/resources/application.properties
+++ b/tracer-sofa-boot-starter/src/test/resources/application.properties
@@ -1,3 +1,4 @@
+spring.application.name=test-app-name
 spring.datasource.url=jdbc:mysql://localhost:3306/sofa
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 spring.datasource.username=xxxx


### PR DESCRIPTION

### Motivation:
目前 sofa-tracer 中 openfeign、sofaboot 等依赖版本太低，使用时会有些问题 


### Modification:
1.升级`spring-cloud-starter-openfeign` 版本到 `3.0.5` 并解决 `Request.headers` 不可编辑的问题 
2.使用 `spring cloud loadbalancer` 替换 `ribbon`
3.升级 `sofaboot dependencies` 的版本到 `3.12.1`, 解决 `spring boot` 和 `spring cloud` 版本依赖冲突问题
4.解决 `sofaboot dependencies` 版本升级之后出现的单测运行问题、接口升级问题


### Result:

Fixes #475 #447 

If there is no issue then describe the changes introduced by this PR.
