### PR TITLE
set origin id into zipkin tags

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/src/main/java/com/alipay/sofa/tracer/plugins/zipkin/adapter/ZipkinV2SpanAdapter.java
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/src/main/java/com/alipay/sofa/tracer/plugins/zipkin/adapter/ZipkinV2SpanAdapter.java
@@ -186,6 +186,10 @@ public class ZipkinV2SpanAdapter {
             zipkinSpan.putTag(e.getKey(), e.getValue().toString());
         }
 
+        SofaTracerSpanContext context = span.getSofaTracerSpanContext();
+        zipkinSpan.putTag("origin.span.id", context.getSpanId());
+        zipkinSpan.putTag("origin.parent.span.id", context.getParentId());
+
         addZipkinTagsWithBaggage(zipkinSpan, span);
     }
 }


### PR DESCRIPTION
### Motivation:

Currently, when convert to zipkin span, we lose the origin spanId and parentSpanId.
So we cannot build the relation for this situation `zipkin app -> sofatracer app`.

### Modification:

Add two tag to save the origin spanId and parentSpanId

### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
