### PR TITLE
Fix the problem of using a higher version of feign

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/carriers/FeignRequestHeadersCarrier.java
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/src/main/java/com/alipay/sofa/tracer/plugins/springcloud/carriers/FeignRequestHeadersCarrier.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.tracer.plugins.springcloud.carriers;
 
-import feign.Request;
 import io.opentracing.propagation.TextMap;
 
 import java.util.ArrayList;
@@ -28,15 +27,15 @@ import java.util.Map;
  * @author: guolei.sgl (guolei.sgl@antfin.com) 2019/3/13 5:09 PM
  * @since:
  **/
-public class FeignRequestCarrier implements TextMap {
+public class FeignRequestHeadersCarrier implements TextMap {
 
-    private Request request;
+    private Map<String, Collection<String>> headers;
 
-    public FeignRequestCarrier(Request request) {
-        if (request == null) {
+    public FeignRequestHeadersCarrier(Map<String, Collection<String>> headers) {
+        if (headers == null) {
             throw new NullPointerException("Headers request should not be null!");
         }
-        this.request = request;
+        this.headers = headers;
     }
 
     @Override
@@ -46,11 +45,11 @@ public class FeignRequestCarrier implements TextMap {
 
     @Override
     public void put(String key, String val) {
-        Collection<String> vals = request.headers().get(key);
+        Collection<String> vals = headers.get(key);
         if (vals == null) {
             vals = new ArrayList<>();
         }
         vals.add(val);
-        request.headers().put(key, vals);
+        headers.put(key, vals);
     }
 }

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/registry/AbstractTextB3Formatter.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/registry/AbstractTextB3Formatter.java
@@ -146,7 +146,6 @@ public abstract class AbstractTextB3Formatter implements RegistryExtractorInject
         carrier.put(TRACE_ID_KEY_HEAD, encodedValue(spanContext.getTraceId()));
         carrier.put(SPAN_ID_KEY_HEAD, encodedValue(spanContext.getSpanId()));
         carrier.put(PARENT_SPAN_ID_KEY_HEAD, encodedValue(spanContext.getParentId()));
-        carrier.put(SPAN_ID_KEY_HEAD, encodedValue(spanContext.getSpanId()));
         carrier.put(SAMPLED_KEY_HEAD, encodedValue(String.valueOf(spanContext.isSampled())));
         //System Baggage items
         for (Map.Entry<String, String> entry : spanContext.getSysBaggage().entrySet()) {


### PR DESCRIPTION
### Motivation:

由于从 OpenFeign 10.7.3 版本开始, requestBody() 这个方法被 OpenFeign 废弃了, 导致 Request.create() 方法报错，feign 调用的日志无法生成。

### Modification:

1. 将 `com.alipay.sofa.tracer.plugins.springcloud.instruments.feign.SofaTracerFeignClient#execute` 方法里 `Request.create(...)...` 需要的 `request.requestBody()` 参数改为 `request.body()`, 以解决高版本 `requestBody()` 方法被废弃的问题。
2. 重构 `com.alipay.sofa.tracer.plugins.springcloud.carriers.FeignRequestCarrier` 方法, 解决 `Request.headers` 不可编辑的问题。see #318

### Result:

Fixes #447

If there is no issue then describe the changes introduced by this PR.
