### PR TITLE
fix(sec): upgrade org.springframework.data:spring-data-mongodb to 3.3.5

### DIFF
--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <version>2.1.8.RELEASE</version>
+            <version>3.4.1</version>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.data:spring-data-mongodb 2.1.8.RELEASE
- [CVE-2022-22980](https://www.oscs1024.com/hd/CVE-2022-22980)


### What did I do？
Upgrade org.springframework.data:spring-data-mongodb from 2.1.8.RELEASE to 3.3.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS