### PR TITLE
feat: Support `java.util.concurrent.Executor` （#515)

### DIFF
--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/async/SofaTraceExecutor.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/async/SofaTraceExecutor.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.common.tracer.core.async;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * @author xYohn
+ * @date 2023/12/7
+ */
+public class SofaTraceExecutor implements Executor {
+
+    private final Executor delegate;
+
+    public SofaTraceExecutor(Executor delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Executes the given command at some time in the future.  The command
+     * may execute in a new thread, in a pooled thread, or in the calling
+     * thread, at the discretion of the {@code Executor} implementation.
+     *
+     * @param command the runnable task
+     * @throws RejectedExecutionException if this task cannot be
+     *                                    accepted for execution
+     * @throws NullPointerException       if command is null
+     */
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(new SofaTracerRunnable(command));
+    }
+}


### PR DESCRIPTION
### Motivation:

SofaTracer does not support delegating `java.util.concurrent.Executor`

### Modification:

add `com.alipay.common.tracer.core.async.SofaTraceExecutor` to support delegating `java.util.concurrent.Executor`

### Result:

Fixes #515. 

If there is no issue then describe the changes introduced by this PR.
