### PR TITLE
Fixed span clone concurrency issues

### DIFF
--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/span/SofaTracerSpan.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/span/SofaTracerSpan.java
@@ -36,10 +36,10 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * SofaTracerSpan
@@ -55,11 +55,11 @@ public class SofaTracerSpan implements Span {
 
     private final List<SofaTracerSpanReferenceRelationship> spanReferences;
     /** tags for String  */
-    private final Map<String, String>                       tagsWithStr          = new LinkedHashMap<>();
+    private final Map<String, String>                       tagsWithStr          = new ConcurrentHashMap<>();
     /** tags for Boolean */
-    private final Map<String, Boolean>                      tagsWithBool         = new LinkedHashMap<>();
+    private final Map<String, Boolean>                      tagsWithBool         = new ConcurrentHashMap<>();
     /** tags for Number  */
-    private final Map<String, Number>                       tagsWithNumber       = new LinkedHashMap<>();
+    private final Map<String, Number>                       tagsWithNumber       = new ConcurrentHashMap<>();
 
     private final List<LogData>                             logs                 = new LinkedList<>();
 

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.3</version>
+        <version>3.1.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### Motivation:

When using com.alipay.common.tracer.core.span.SofaTracerSpan#cloneInstance, it may lead to concurrency safety issues.

### Modification:

Change the class that causes concurrency issues: linkedhashmap, to concurrenthashmap. Note that there may be a loss of order here, but there is no need for insertion order in the code, so this modification can be made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated version from `3.1.3` to `3.1.4-SNAPSHOT` across various components for consistency and future enhancements.

- **Improvements**
  - Enhanced thread safety by replacing `LinkedHashMap` with `ConcurrentHashMap` for tag storage in `SofaTracerSpan`.

- **Tests**
  - Added file handling logic in `SofaTracerTest` to improve test robustness.
  - Included error message printing in `TestUtil` for better debugging during test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->