### PR TITLE
Fixed span clone concurrency issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>3.1.4-SNAPSHOT</version>
+    <version>3.1.5</version>
     <packaging>pom</packaging>
     <name>tracer-all-parent</name>
     <description>Alipay SOFATracer Log Implemented by OpenTracing</description>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>3.1.4-SNAPSHOT</version>
+    <version>3.1.5</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/span/SofaTracerSpan.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/span/SofaTracerSpan.java
@@ -36,10 +36,10 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * SofaTracerSpan
@@ -61,7 +61,7 @@ public class SofaTracerSpan implements Span {
     /** tags for Number  */
     private final Map<String, Number>                       tagsWithNumber       = new ConcurrentHashMap<>();
 
-    private final List<LogData>                             logs                 = new LinkedList<>();
+    private final ConcurrentLinkedQueue<LogData>            logs                 = new ConcurrentLinkedQueue<>();
 
     private String                                          operationName        = StringUtils.EMPTY_STRING;
 
@@ -436,7 +436,7 @@ public class SofaTracerSpan implements Span {
         return sofaTracerSpanContext;
     }
 
-    public List<LogData> getLogs() {
+    public ConcurrentLinkedQueue<LogData> getLogs() {
         return logs;
     }
 

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/SofaTracerTest.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/tracertest/SofaTracerTest.java
@@ -143,10 +143,10 @@ public class SofaTracerTest extends AbstractTestBase {
                 //Test print one only put one tag
                 assertTrue(contextStr.contains(Tags.SPAN_KIND.getKey())
                         && contextStr.contains(Tags.SPAN_KIND_CLIENT));
-            } catch (IOException e) {
+            } catch (IndexOutOfBoundsException | IOException e) {
                 throw new AssertionError(e);
             }
-        }, 500);
+        }, 5000);
     }
 
     /**

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Motivation:
When using com.alipay.common.tracer.core.span.SofaTracerSpan#cloneInstance, it may lead to concurrency safety issues.

Modification:
Change the class that causes concurrency issues: LinkedList, to ConcurrentLinkedQueue.
