### PR TITLE
Upgrade zipkin-repoter 3.4.0

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-reporter</artifactId>
-            <version>2.7.15</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/src/main/java/com/alipay/sofa/tracer/plugins/zipkin/sender/ZipkinRestTemplateSender.java
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/src/main/java/com/alipay/sofa/tracer/plugins/zipkin/sender/ZipkinRestTemplateSender.java
@@ -22,8 +22,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.web.client.RestTemplate;
-import zipkin2.Call;
-import zipkin2.codec.Encoding;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.Sender;
 

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/src/test/java/com/alipay/sofa/tracer/plugins/zipkin/ZipkinRestTemplateSenderTest.java
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/src/test/java/com/alipay/sofa/tracer/plugins/zipkin/ZipkinRestTemplateSenderTest.java
@@ -23,8 +23,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.web.client.RestTemplate;
-import zipkin2.Call;
-import zipkin2.codec.Encoding;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Encoding;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
### Motivation:

sofaboot support 3.3.2 failed：https://github.com/sofastack/sofa-boot/pull/1335

The reason is that sofa tracer is not compatible with zipkin repoter.

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Upgraded the `zipkin-reporter` dependency to version `3.4.0`, which may introduce new features and improvements to tracing capabilities.

- **Bug Fixes**
	- Adjusted imports in the Zipkin integration components to align with the latest library structure, potentially improving functionality and stability in tracing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->