### PR TITLE
Fix tracer runnable mdc clean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>3.1.7-SNAPSHOT</version>
+    <version>3.1.7</version>
     <packaging>pom</packaging>
     <name>tracer-all-parent</name>
     <description>Alipay SOFATracer Log Implemented by OpenTracing</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>tracer-all-parent</name>
     <description>Alipay SOFATracer Log Implemented by OpenTracing</description>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>3.1.7-SNAPSHOT</version>
+    <version>3.1.7</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/async/FunctionalAsyncSupport.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/async/FunctionalAsyncSupport.java
@@ -50,7 +50,8 @@ public class FunctionalAsyncSupport {
     public void doFinally() {
         if (Thread.currentThread().getId() != tid) {
             if (currentSpan != null) {
-                traceContext.pop();
+                SofaTracerSpan popped = traceContext.pop();
+                SpanExtensionFactory.logStoppedSpan(popped);
             }
         }
     }

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7-SNAPSHOT</version>
+        <version>3.1.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### Motivation:

SofaTracerRunnable do not clean up the MDC upon exit, causing an MDC leakage.

### Modification:

Clean up MDC context upon exit



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version across multiple projects to `3.1.7`, indicating potential new features and improvements.
- **Bug Fixes**
	- Minor version updates may resolve existing issues and enhance overall performance.
- **Chores**
	- General dependency management improvements reflected in the version updates across various plugins and projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->