### PR TITLE
fix unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.10.19</version>
+                <version>4.3.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/test/java/com/sofa/tracer/plugins/datasource/base/BaseTest.java
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/test/java/com/sofa/tracer/plugins/datasource/base/BaseTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.sql.DataSource;
 import java.io.File;

--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tracer-core/src/test/java/com/alipay/common/tracer/core/benchmark/CountBenchmark.java
+++ b/tracer-core/src/test/java/com/alipay/common/tracer/core/benchmark/CountBenchmark.java
@@ -17,7 +17,6 @@
 package com.alipay.common.tracer.core.benchmark;
 
 import com.alipay.common.tracer.core.utils.StringUtils;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -77,7 +76,6 @@ public class CountBenchmark {
         blackhole.consume(StringUtils.countMatches(RPC_ID, '.'));
     }
 
-    @Test
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder().include(CountBenchmark.class.getSimpleName()).forks(1)
             .build();

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -19,6 +19,10 @@
     <dependencies>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
             <artifactId>tracer-core</artifactId>
         </dependency>
         <dependency>
@@ -259,13 +263,18 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>cz.jirutka.spring</groupId>
             <artifactId>embedmongo-spring</artifactId>
             <version>1.3.1</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/listener/SofaTracerConfigurationListener.java
+++ b/tracer-sofa-boot-starter/src/main/java/com/alipay/sofa/tracer/boot/listener/SofaTracerConfigurationListener.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.tracer.boot.listener;
 
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.utils.StringUtils;
+import com.alipay.sofa.boot.util.SofaBootEnvUtils;
 import com.alipay.sofa.tracer.boot.properties.SofaTracerProperties;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -27,9 +28,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * Parse SOFATracer Configuration in early stage.
@@ -46,7 +45,7 @@ public class SofaTracerConfigurationListener
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         ConfigurableEnvironment environment = event.getEnvironment();
 
-        if (isSpringCloudBootstrapEnvironment(environment)) {
+        if (SofaBootEnvUtils.isSpringCloudBootstrapEnvironment(environment)) {
             return;
         }
 
@@ -111,20 +110,5 @@ public class SofaTracerConfigurationListener
     @Override
     public int getOrder() {
         return HIGHEST_PRECEDENCE + 30;
-    }
-
-    private boolean isSpringCloudBootstrapEnvironment(Environment environment) {
-        if (!(environment instanceof ConfigurableEnvironment)) {
-            return false;
-        } else {
-            return !((ConfigurableEnvironment) environment).getPropertySources().contains(
-                "sofaBootstrap")
-                   && isSpringCloud();
-        }
-    }
-
-    private boolean isSpringCloud() {
-        return ClassUtils.isPresent("org.springframework.cloud.bootstrap.BootstrapConfiguration",
-            null);
     }
 }

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestBase.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestBase.java
@@ -21,7 +21,7 @@ import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.reporter.digest.manager.SofaTracerDigestReporterAsyncManager;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterCycleTimesManager;
 import com.alipay.common.tracer.core.reporter.stat.manager.SofaTracerStatisticReporterManager;
-import com.alipay.sofa.infra.listener.SofaBootstrapRunListener;
+import com.alipay.sofa.boot.listener.SofaBootstrapRunListener;
 import com.alipay.sofa.tracer.plugins.springmvc.SpringMvcTracer;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestCloudBase.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/AbstractTestCloudBase.java
@@ -18,7 +18,7 @@ package com.alipay.sofa.tracer.boot.base;
 
 import com.alipay.common.tracer.core.appender.TracerLogRootDaemon;
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
-import com.alipay.sofa.infra.listener.SofaBootstrapRunListener;
+import com.alipay.sofa.boot.listener.SofaBootstrapRunListener;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = SpringBootWebApplication.class, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @TestPropertySource(locations = "classpath:application.properties")
-public class AbstractTestCloudBase {
+public abstract class AbstractTestCloudBase {
     protected static String logDirectoryPath = TracerLogRootDaemon.LOG_FILE_DIR;
 
     @BeforeClass

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/ConfigurationHolderListener.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/ConfigurationHolderListener.java
@@ -18,7 +18,7 @@ package com.alipay.sofa.tracer.boot.base;
 
 import com.alipay.common.tracer.core.configuration.SofaTracerConfiguration;
 import com.alipay.common.tracer.core.utils.StringUtils;
-import com.alipay.sofa.infra.utils.SOFABootEnvUtils;
+import com.alipay.sofa.boot.util.SofaBootEnvUtils;
 import com.alipay.sofa.tracer.boot.properties.SofaTracerProperties;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
@@ -33,7 +33,7 @@ public class ConfigurationHolderListener implements
     @Override
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         ConfigurableEnvironment environment = event.getEnvironment();
-        if (SOFABootEnvUtils.isSpringCloudBootstrapEnvironment(environment)) {
+        if (SofaBootEnvUtils.isSpringCloudBootstrapEnvironment(environment)) {
             return;
         }
         SofaTracerProperties sofaTracerProperties = new SofaTracerProperties();

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/SpringBootWebApplication.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/base/SpringBootWebApplication.java
@@ -17,6 +17,7 @@
 package com.alipay.sofa.tracer.boot.base;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportResource;
@@ -28,7 +29,11 @@ import org.springframework.web.client.RestTemplate;
  * @author yangguanchao
  * @since 2018/04/30
  */
-@org.springframework.boot.autoconfigure.SpringBootApplication
+@org.springframework.boot.autoconfigure.SpringBootApplication(
+        exclude = {
+                EmbeddedMongoAutoConfiguration.class
+        }
+)
 @ImportResource({ "classpath:hikariDataSource.xml" })
 public class SpringBootWebApplication {
 

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/config/ConfigurationTest.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/config/ConfigurationTest.java
@@ -19,17 +19,12 @@ package com.alipay.sofa.tracer.boot.config;
 import com.alipay.common.tracer.core.appender.file.TimedRollingFileAppender;
 import com.alipay.sofa.tracer.boot.base.AbstractTestBase;
 import com.alipay.sofa.tracer.boot.base.ConfigurationHolder;
-import com.alipay.sofa.tracer.boot.base.SpringBootWebApplication;
 import com.alipay.sofa.tracer.boot.properties.SofaTracerProperties;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.File;
 import java.util.Map;

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### Motivation:

修复单元测试，主要修复tracer-sofa-boot-starter模块下单元测试不能正常运行的问题。

### Modification:
1. 调整embedmongo-spring为可选的编译期依赖，修复源码编译问题、
2. 添加com.alipay.sofa:sofa-boot依赖
https://github.com/sofastack/sofa-tracer/pull/512 该pr中移除了infra-sofa-boot-starter依赖，这导致运行时缺少了com.alipay.sofa.boot.listener.SofaBootstrapRunListener，从而导致SofaTracerConfigurationListener无法正常的进行参数注入，测试用例无法正常执行。

<img width="818" alt="image" src="https://github.com/user-attachments/assets/ced5b281-8716-4143-bdbf-2fe6b4a0052b">

项目正常依赖的sofaboot版本中，SofaBootstrapRunListener已经迁移到了com.alipay.sofa:sofa-boot中，不再需要依赖infra-sofa-boot-starter，重新将该依赖补回即可。


### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency for `sofa-boot`, enhancing project functionality.
	- Added a new `junit` dependency to improve testing capabilities.

- **Bug Fixes**
	- Updated `mockito-core` dependency to version `4.3.0`, improving testing performance and reliability.
	- Removed specific version specifications for `mockito-core` in several plugins, allowing for the use of the latest version.

- **Refactor**
	- Simplified the method for checking Spring Cloud bootstrap environment.
	- Changed `AbstractTestCloudBase` from a concrete to an abstract class to better serve as a base for other classes.

- **Chores**
	- Removed unnecessary import statements to streamline code and reduce dependencies.
	- Commented out unused test methods to clean up the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->