### PR TITLE
Disruptor event clear

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>tracer-all-parent</artifactId>
-    <version>3.1.7</version>
+    <version>3.1.8-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>tracer-all-parent</name>
     <description>Alipay SOFATracer Log Implemented by OpenTracing</description>

--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-2.6.x-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-common-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-dubbo-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-flexible-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-kafkamq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-mongodb-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rabbitmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-resttmplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-rocketmq-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-spring-cloud-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmessage-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-springmvc-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
+++ b/sofa-tracer-plugins/sofa-tracer-zipkin-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tracer-all/pom.xml
+++ b/tracer-all/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tracer-all</artifactId>
-    <version>3.1.7</version>
+    <version>3.1.8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>SOFATracer in one without SOFABoot starter</name>

--- a/tracer-core/pom.xml
+++ b/tracer-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/AsyncCommonAppenderManager.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/AsyncCommonAppenderManager.java
@@ -165,6 +165,7 @@ public class AsyncCommonAppenderManager {
                 try {
                     appender.append(string);
                     appender.flush();
+                    event.clear();
                 } catch (Exception e) {
                     //todo Globally keep a synchronized log for synchronizing print logs at some key points
                     if (string != null) {

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/AsyncCommonDigestAppenderManager.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/AsyncCommonDigestAppenderManager.java
@@ -207,7 +207,7 @@ public class AsyncCommonDigestAppenderManager {
                             appender.append(encodedStr);
                         }
                         appender.flush();
-
+                        event.clear();
                     }
                 } catch (Exception e) {
                     SofaTracerSpanContext sofaTracerSpanContext = sofaTracerSpan

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/ObjectEvent.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/ObjectEvent.java
@@ -18,23 +18,10 @@ package com.alipay.common.tracer.core.appender.manager;
 
 /**
  *
- * @author luoguimu123
- * @version $Id: StringEvent.java, v 0.1 November 21, 2017 7:01 PM luoguimu123 Exp $
+ * @author songzijie
+ * @version $Id: ObjectEvent.java, v 0.1 2024-10-08 16:10 songzijie Exp $$
  */
-public class StringEvent implements ObjectEvent {
+public interface ObjectEvent {
 
-    private volatile String string;
-
-    public String getString() {
-        return string;
-    }
-
-    public void setString(String string) {
-        this.string = string;
-    }
-
-    @Override
-    public void clear() {
-        setString(null);
-    }
+    void clear();
 }

--- a/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/SofaTracerSpanEvent.java
+++ b/tracer-core/src/main/java/com/alipay/common/tracer/core/appender/manager/SofaTracerSpanEvent.java
@@ -21,7 +21,7 @@ import com.alipay.common.tracer.core.span.SofaTracerSpan;
 /**
  * @author liangen 3/10/17
  */
-public class SofaTracerSpanEvent {
+public class SofaTracerSpanEvent implements ObjectEvent {
     private volatile SofaTracerSpan sofaTracerSpan;
 
     /**
@@ -40,5 +40,10 @@ public class SofaTracerSpanEvent {
      */
     public void setSofaTracerSpan(SofaTracerSpan sofaTracerSpan) {
         this.sofaTracerSpan = sofaTracerSpan;
+    }
+
+    @Override
+    public void clear() {
+        setSofaTracerSpan(null);
     }
 }

--- a/tracer-extensions/pom.xml
+++ b/tracer-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>tracer-extensions</artifactId>

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/core-test/pom.xml
+++ b/tracer-test/core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j-test/pom.xml
+++ b/tracer-test/log4j-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/log4j2-test/pom.xml
+++ b/tracer-test/log4j2-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tracer-test/logback-test/pom.xml
+++ b/tracer-test/logback-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tracer-all-parent</artifactId>
         <groupId>com.alipay.sofa</groupId>
-        <version>3.1.7</version>
+        <version>3.1.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Fix the issue of span events escaping to the old generation in low traffic scenarios. Ensure that the Disruptor consumer sets the carried content to null after processing the event, so it can be garbage collected during YGC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface `ObjectEvent` to facilitate state clearing for implementing objects.
	- Updated `SofaTracerSpanEvent` and `StringEvent` classes to implement the `ObjectEvent` interface, adding a `clear()` method to reset their state.

- **Improvements**
	- Updated version numbers across multiple projects and plugins to `3.1.8-SNAPSHOT`, indicating ongoing development.

- **Bug Fixes**
	- Corrected typographical errors in the properties section of the POM files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->