### PR TITLE
feat: support dbcp2

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/utils/DataSourceUtils.java
+++ b/sofa-tracer-plugins/sofa-tracer-datasource-plugin/src/main/java/com/alipay/sofa/tracer/plugins/datasource/utils/DataSourceUtils.java
@@ -41,6 +41,7 @@ public class DataSourceUtils {
     public static final String DS_DRUID_CLASS      = "com.alibaba.druid.pool.DruidDataSource";
 
     public static final String DS_DBCP_CLASS       = "org.apache.commons.dbcp.BasicDataSource";
+    public static final String DS_DBCP2_CLASS      = "org.apache.commons.dbcp2.BasicDataSource";
 
     public static final String DS_C3P0_CLASS       = "com.mchange.v2.c3p0.ComboPooledDataSource";
 
@@ -69,11 +70,13 @@ public class DataSourceUtils {
     }
 
     public static boolean isDbcpDataSource(Object dataSource) {
-        return isTargetDataSource(DS_DBCP_CLASS, dataSource);
+        return isTargetDataSource(DS_DBCP_CLASS, dataSource)
+               || isTargetDataSource(DS_DBCP2_CLASS, dataSource);
     }
 
     public static boolean isDbcpDataSource(String clazzType) {
-        return !StringUtils.isBlank(clazzType) && DS_DBCP_CLASS.equals(clazzType);
+        return !StringUtils.isBlank(clazzType)
+               && (DS_DBCP_CLASS.equals(clazzType) || DS_DBCP2_CLASS.equals(clazzType));
     }
 
     public static boolean isC3p0DataSource(Object dataSource) {

--- a/tracer-sofa-boot-starter/pom.xml
+++ b/tracer-sofa-boot-starter/pom.xml
@@ -237,6 +237,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.kstyrc</groupId>
             <artifactId>embedded-redis</artifactId>
             <version>0.6</version>

--- a/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/datasource/DataSourceUrlTest.java
+++ b/tracer-sofa-boot-starter/src/test/java/com/alipay/sofa/tracer/boot/datasource/DataSourceUrlTest.java
@@ -51,6 +51,14 @@ public class DataSourceUrlTest {
         Assert.assertNotNull(method);
         Assert.assertEquals("test-url", method.invoke(basicDataSource));
 
+        // dbcp2
+        org.apache.commons.dbcp2.BasicDataSource basicDataSource2 = new org.apache.commons.dbcp2.BasicDataSource();
+        basicDataSource2.setUrl("test-url");
+        method = ReflectionUtils.findMethod(basicDataSource2.getClass(),
+                DataSourceUtils.METHOD_GET_URL);
+        Assert.assertNotNull(method);
+        Assert.assertEquals("test-url", method.invoke(basicDataSource2));
+
         // tomcat datasource
         DataSource dataSource = new DataSource();
         dataSource.setUrl("test-url");


### PR DESCRIPTION
### Motivation:

datasource插件支持dbcp2

### Modification:

DatasourceUtils支持识别dbcp2的数据源

### Result:

能够正常识别dbcp2数据源并打印trace日志

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for DBCP2 data sources, enhancing the system's ability to recognize different database connection pooling options.
- **Bug Fixes**
	- Improved the logic for identifying DBCP data sources to include DBCP2.
- **Tests**
	- Introduced a new test case for validating the URL retrieval from DBCP2 data sources. 
- **Chores**
	- Added a new dependency for `commons-dbcp2` to enhance testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->