### PR TITLE
Redis代理连接执行unlink方法传参丢失

### DIFF
--- a/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingRedisConnection.java
+++ b/sofa-tracer-plugins/sofa-tracer-redis-plugin/src/main/java/com/sofa/alipay/tracer/plugins/spring/redis/connections/TracingRedisConnection.java
@@ -202,7 +202,7 @@ public class TracingRedisConnection implements RedisConnection {
 
     @Override
   public Long exists(byte[]... keys) {
-    return actionWrapper.doInScope(RedisCommand.EXISTS, keys, connection::exists);
+    return actionWrapper.doInScope(RedisCommand.EXISTS, keys, () -> connection.exists(keys));
   }
 
     @Override
@@ -212,7 +212,7 @@ public class TracingRedisConnection implements RedisConnection {
 
     @Override
   public Long unlink(byte[]... keys) {
-    return actionWrapper.doInScope(RedisCommand.UNLINK, keys, connection::unlink);
+    return actionWrapper.doInScope(RedisCommand.UNLINK, keys, () -> connection.unlink(keys));
   }
 
     @Override
@@ -222,7 +222,7 @@ public class TracingRedisConnection implements RedisConnection {
 
     @Override
   public Long touch(byte[]... keys) {
-    return actionWrapper.doInScope(RedisCommand.TOUCH, keys, connection::touch);
+    return actionWrapper.doInScope(RedisCommand.TOUCH, keys, () -> connection.touch(keys));
   }
 
     @Override


### PR DESCRIPTION
TracingRedisConnection在代理unlink命令时没有将参数参入被代理的连接中